### PR TITLE
Add email-based login and profile page

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from specialwidget.views import *
-from django.contrib.auth import views
+from django.contrib.auth import views as auth_views
 from specialwidget.help import *
 
 
@@ -10,6 +10,16 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include('allauth.urls')),
     path("", home, name="home"),
+    path('register/', register, name='register'),
+    path('login/', login_view, name='login'),
+    path('logout/', logout_view, name='logout'),
+    path('profile/', profile, name='profile'),
+
+    # password reset
+    path('password_reset/', auth_views.PasswordResetView.as_view(template_name='registration/password_reset_form.html'), name='password_reset'),
+    path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(template_name='registration/password_reset_done.html'), name='password_reset_done'),
+    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name='registration/password_reset_confirm.html'), name='password_reset_confirm'),
+    path('reset/done/', auth_views.PasswordResetCompleteView.as_view(template_name='registration/password_reset_complete.html'), name='password_reset_complete'),
 
     ##dashboard 
     path("dashboard/", dashboard, name="dashboard"),

--- a/app/specialwidget/forms.py
+++ b/app/specialwidget/forms.py
@@ -38,3 +38,20 @@ class AddSpecialForm(ModelForm):
         self.helper.form_show_labels = False 
 
 
+
+class SignUpForm(forms.Form):
+    email = forms.EmailField(label="Email", max_length=254)
+    password = forms.CharField(label="Password", widget=forms.PasswordInput)
+
+    def save(self, commit=True):
+        email = self.cleaned_data["email"]
+        password = self.cleaned_data["password"]
+        user = User(username=email, email=email)
+        user.set_password(password)
+        if commit:
+            user.save()
+        return user
+
+class EmailAuthenticationForm(AuthenticationForm):
+    username = UsernameField(label="Email", widget=forms.EmailInput(attrs={"autofocus": True}))
+    remember_me = forms.BooleanField(required=False, initial=False, label="Remember me")

--- a/app/specialwidget/help.py
+++ b/app/specialwidget/help.py
@@ -4,7 +4,7 @@ import requests
 import os
 import json
 import stripe
-from specialwidget.forms import AddSpecialForm
+from specialwidget.forms import AddSpecialForm, SignUpForm
 from specialwidget.models import Payment, Membership, Special,Subscriber,GMBAccounts,GMBLocations
 from datetime import datetime
 from django.http import HttpResponse, JsonResponse,HttpResponseRedirect
@@ -31,10 +31,10 @@ def colorpicker(request):
 
 def add_auth_user(request):
     if request.method == "GET":
-        
+        form = SignUpForm()
         return render(request,'specialwidget/special_form.html', {'form':form})
     if request.method == "POST":
-        form = RegisterForm(request.POST)
+        form = SignUpForm(request.POST)
         if form.is_valid():
             f = form.save()
             membership = Membership.objects.get(id=request.POST.get('member_id'))

--- a/app/specialwidget/templates/registration/login.html
+++ b/app/specialwidget/templates/registration/login.html
@@ -2,22 +2,34 @@
 {% load static %}
 
 {% block title %}
-
 {% endblock %}
 
 {% block content %}
 <div class="h-100 d-flex align-items-center justify-content-center">
-    <div class="py-auto text-center"style="margin-top:15%;">
-        <form method="post">
-            {{form}}
+    <div class="py-auto text-center" style="margin-top:15%;">
+        <form method="post" class="border p-4 rounded shadow-sm">
             {% csrf_token %}
-            <button type="submit" class="btn btn-lg bg-disabled shadow-sm px-4"><i class="fa-solid fa-egg text-black-50">  Continue</i></button>
-          </form>
-      
+            <div class="mb-3">
+                {{ form.username.label_tag }}
+                {{ form.username }}
+            </div>
+            <div class="mb-3">
+                {{ form.password.label_tag }}
+                {{ form.password }}
+            </div>
+            <div class="form-check mb-3">
+                {{ form.remember_me }} {{ form.remember_me.label_tag }}
+            </div>
+            <div class="mb-3 text-end">
+                <a href="{% url 'password_reset' %}">Forgot password?</a>
+            </div>
+            <button type="submit" class="btn btn-lg bg-disabled shadow-sm px-4">
+                <i class="fa-solid fa-egg text-black-50"> Continue</i>
+            </button>
+        </form>
     </div>
-  </div>
+</div>
 
-
-<!-- Page Content Ends Here-->   
+<!-- Page Content Ends Here-->
 
 {% endblock %}

--- a/app/specialwidget/templates/registration/password_reset_complete.html
+++ b/app/specialwidget/templates/registration/password_reset_complete.html
@@ -1,0 +1,6 @@
+{% extends 'specialwidget/base.html' %}
+{% block content %}
+<div class="container mt-5">
+  <p>Your password has been set. <a href="{% url 'login' %}">Log in</a></p>
+</div>
+{% endblock %}

--- a/app/specialwidget/templates/registration/password_reset_confirm.html
+++ b/app/specialwidget/templates/registration/password_reset_confirm.html
@@ -1,0 +1,11 @@
+{% extends 'specialwidget/base.html' %}
+{% block content %}
+<div class="container mt-5">
+  <h2>Set new password</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Change password</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/specialwidget/templates/registration/password_reset_done.html
+++ b/app/specialwidget/templates/registration/password_reset_done.html
@@ -1,0 +1,6 @@
+{% extends 'specialwidget/base.html' %}
+{% block content %}
+<div class="container mt-5">
+  <p>We've emailed you instructions for setting your password.</p>
+</div>
+{% endblock %}

--- a/app/specialwidget/templates/registration/password_reset_form.html
+++ b/app/specialwidget/templates/registration/password_reset_form.html
@@ -1,0 +1,11 @@
+{% extends 'specialwidget/base.html' %}
+{% block content %}
+<div class="container mt-5">
+  <h2>Reset password</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Send email</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/specialwidget/templates/registration/register.html
+++ b/app/specialwidget/templates/registration/register.html
@@ -1,26 +1,22 @@
 {% extends 'specialwidget/base.html' %}
 {% load static %}
-{% load widget_tweaks %}
-{% block title %}
-
-{% endblock %}
+{% block title %}{% endblock %}
 
 {% block content %}
 <div class="h-100 d-flex align-items-center justify-content-center">
     <div class="col-md-3 p-5 text-center border shadow-sm rounded" style="margin-top:15%;background-image: linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);">
         <form method="POST" action="{% url 'register' %}">
-
-
-          {% render_field form.username placeholder=form.username.label class+="form-control mb-3" %}
-          {% render_field form.email placeholder=form.email.label class+="form-control mb-3" %}
-          {% render_field form.password1 placeholder=form.password1.label class+="form-control mb-3" %}
-          {% render_field form.password2 placeholder=form.password2.label class+="form-control mb-3" %}
-
-            {% csrf_token %}
-            <button type="submit" class="btn btn-lg bg-light shadow-sm px-4 mt-3"><i class="fa-solid fa-egg text-black-50">  Continue</i></button>
-
-          </form>
-      
+          {% csrf_token %}
+          <div class="mb-3">
+            {{ form.email.label_tag }}
+            {{ form.email }}
+          </div>
+          <div class="mb-3">
+            {{ form.password.label_tag }}
+            {{ form.password }}
+          </div>
+          <button type="submit" class="btn btn-lg bg-light shadow-sm px-4 mt-3"><i class="fa-solid fa-egg text-black-50">  Continue</i></button>
+        </form>
     </div>
   </div>
 {% endblock %}

--- a/app/specialwidget/templates/specialwidget/profile.html
+++ b/app/specialwidget/templates/specialwidget/profile.html
@@ -1,0 +1,38 @@
+{% extends 'specialwidget/base.html' %}
+{% load static %}
+{% block title %}{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+  <h2 class="mb-4">Profile</h2>
+  <h4>Active Specials</h4>
+  <ul class="list-group mb-4">
+    {% for s in active_specials %}
+      <li class="list-group-item">{{ s.title }} - {{ s.price }}</li>
+    {% empty %}
+      <li class="list-group-item">No active specials.</li>
+    {% endfor %}
+  </ul>
+
+  <h4>Expired Specials</h4>
+  <ul class="list-group mb-4">
+    {% for s in expired_specials %}
+      <li class="list-group-item">{{ s.title }} - {{ s.price }}</li>
+    {% empty %}
+      <li class="list-group-item">No expired specials.</li>
+    {% endfor %}
+  </ul>
+
+  <h4>Email Signups</h4>
+  <ul class="list-group mb-4">
+    {% for sub in subscribers %}
+      <li class="list-group-item">{{ sub.email }}</li>
+    {% empty %}
+      <li class="list-group-item">No subscribers.</li>
+    {% endfor %}
+  </ul>
+
+  <h4>Embed Code</h4>
+  <textarea class="w-100 form-control form-control-sm p-3" style="height:120px;overflow:auto;" onclick="copyToClipboard()" id="embedblock">{{ embed_code|safe }}</textarea>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Introduce custom signup and email-based authentication forms using email as username and support a remember-me option.
- Add registration, login/logout, profile and password-reset views with corresponding URL routes.
- Create profile page to display active and expired specials, subscriber emails and widget embed code.

## Testing
- `python manage.py test` *(fails: SyntaxError in specialwidget.tests)*

------
https://chatgpt.com/codex/tasks/task_e_689633b000cc8332bc39cdf5bceda8ce