### PR TITLE
Add navigation and Bootstrap styling to dashboard and auth pages

### DIFF
--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -73,13 +73,26 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm sticky-top">
   <div class="container">
-    <a class="navbar-brand" href="#">Appertivo</a>
-    <div class="d-flex">
-      {% if request.user.is_authenticated %}
-        <span class="text-muted small">Welcome, {{ request.user_profile }}</span>
-      {% else %}
-        <span class="text-muted small">Welcome, Guest</span>
-      {% endif %}
+    <a class="navbar-brand" href="{% url 'dashboard' %}">Appertivo</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        {% if request.user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'my_specials' %}">My Specials</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
+        {% endif %}
+      </ul>
+      <span class="navbar-text ms-3">
+        {% if request.user.is_authenticated %}
+          Welcome, {{ request.user_profile }}
+        {% else %}
+          Welcome, Guest
+        {% endif %}
+      </span>
     </div>
   </div>
 </nav>

--- a/templates/app/my_specials.html
+++ b/templates/app/my_specials.html
@@ -1,7 +1,44 @@
-
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Specials</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body {background-color:#f8f9fa;color:#49475B;}
+    .brand-purple {color:#B993D6;}
+    .brand-orange {background-color:#f08000;color:#fff;}
+    .brand-orange:hover {background-color:#e06e00;color:#fff;}
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+  <div class="container">
+    <a class="navbar-brand" href="{% url 'dashboard' %}">Appertivo</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        {% if request.user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'my_specials' %}">My Specials</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
 
 <div class="container mt-5">
-  <h2 class="mb-4 brand-purple">Your Past Specials</h2>
+  <h2 class="mb-4 brand-purple text-center">Your Past Specials</h2>
   {% include "app/partials/specials_list.html" %}
 </div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -14,6 +14,25 @@
   </style>
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+  <div class="container">
+    <a class="navbar-brand" href="{% url 'dashboard' %}">Appertivo</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        {% if request.user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'my_specials' %}">My Specials</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+
 <div class="container col-lg-4 col-md-6 col-sm-10 mt-5">
   <h2 class="mb-4 text-center brand-purple">Login</h2>
   <form method="post">
@@ -39,5 +58,6 @@
     <a href="{% url 'password_reset' %}">Forgot password?</a> | <a href="{% url 'signup' %}">Sign up</a>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add navbar links for login, logout, and My Specials on dashboard
- Create full Bootstrap-styled My Specials page with shared navbar
- Add shared navbar and Bootstrap script to login page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689648a4fe508332a5f69914a83b5f1c