### PR TITLE
Handle missing image field in inline updates

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -190,6 +190,8 @@ def special_inline_update(request, pk):
     if request.method == "POST":
         # Create a mutable copy of POST data
         post_data = request.POST.copy()
+        if 'image' not in request.FILES:
+            post_data.pop('image', None)
         
         # Ensure all required fields are present with current values
         required_fields = {


### PR DESCRIPTION
## Summary
- Avoid passing empty `image` field when inline updating specials

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965010dc5083329757d13d669828b9