### PR TITLE
Add connection integrations section

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -30,3 +30,41 @@ class SpecialFormTemplateTests(TestCase):
         html = self.render()
         self.assertTrue('function bindPrice' in html)
         self.assertEqual(html.count('function bindCTA'), 1)
+
+
+class ConnectionPartialTests(TestCase):
+    def render(self):
+        return render_to_string("app/partials/connection.html")
+
+    def test_buttons_present(self):
+        html = self.render()
+        platforms = [
+            "DoorDash",
+            "Grubhub",
+            "Wix",
+            "Uber Eats",
+            "WordPress",
+            "Squarespace",
+            "Webflow",
+        ]
+        for name in platforms:
+            self.assertIn(name, html)
+
+    def test_button_order(self):
+        html = self.render()
+        order = [
+            html.index("DoorDash"),
+            html.index("Grubhub"),
+            html.index("Wix"),
+            html.index("Uber Eats"),
+            html.index("WordPress"),
+            html.index("Squarespace"),
+            html.index("Webflow"),
+        ]
+        self.assertEqual(order, sorted(order))
+
+
+class DashboardTemplateTests(TestCase):
+    def test_connections_partial_included(self):
+        html = render_to_string("app/dashboard.html", {"specials": [], "form": None})
+        self.assertIn("integration-connections", html)

--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -146,6 +146,7 @@
     </div>
 </div>
     </div>
-  </section>
+</section>
+{% include 'app/partials/connection.html' %}
 {% endblock %}
 

--- a/templates/app/partials/connection.html
+++ b/templates/app/partials/connection.html
@@ -1,0 +1,74 @@
+<section id="integration-connections" class="container py-5">
+  <h2 class="h4 mb-4">Integrations</h2>
+  <div class="d-grid gap-2">
+    <!-- DoorDash -->
+    <button class="btn text-white" style="background-color:#FF3008" data-bs-toggle="collapse" data-bs-target="#instr-doordash" aria-expanded="false" aria-controls="instr-doordash">
+      <i class="fa-brands fa-doordash me-2"></i>DoorDash
+    </button>
+    <div class="collapse" id="instr-doordash">
+      <div class="card card-body text-dark">
+        <p>Use your DoorDash merchant portal to add the Appertivo widget link to your menu or promotions page.</p>
+      </div>
+    </div>
+
+    <!-- Grubhub -->
+    <button class="btn text-white" style="background-color:#F6613A" data-bs-toggle="collapse" data-bs-target="#instr-grubhub" aria-expanded="false" aria-controls="instr-grubhub">
+      <i class="fa-brands fa-grubhub me-2"></i>Grubhub
+    </button>
+    <div class="collapse" id="instr-grubhub">
+      <div class="card card-body text-dark">
+        <p>Embed your specials link in the Grubhub promotions area to direct customers to your latest offers.</p>
+      </div>
+    </div>
+
+    <!-- Wix -->
+    <button class="btn text-dark" style="background-color:#FFCB00" data-bs-toggle="collapse" data-bs-target="#instr-wix" aria-expanded="false" aria-controls="instr-wix">
+      <i class="fa-brands fa-wix me-2"></i>Wix
+    </button>
+    <div class="collapse" id="instr-wix">
+      <div class="card card-body text-dark">
+        <p>Add the embed code to a custom HTML element on your Wix site to display the widget.</p>
+      </div>
+    </div>
+
+    <!-- Uber Eats -->
+    <button class="btn text-white" style="background-color:#06C167" data-bs-toggle="collapse" data-bs-target="#instr-ubereats" aria-expanded="false" aria-controls="instr-ubereats">
+      <i class="fa-brands fa-uber me-2"></i>Uber Eats
+    </button>
+    <div class="collapse" id="instr-ubereats">
+      <div class="card card-body text-dark">
+        <p>Share the specials URL in your Uber Eats profile to entice delivery customers.</p>
+      </div>
+    </div>
+
+    <!-- WordPress -->
+    <button class="btn text-white" style="background-color:#21759B" data-bs-toggle="collapse" data-bs-target="#instr-wordpress" aria-expanded="false" aria-controls="instr-wordpress">
+      <i class="fa-brands fa-wordpress me-2"></i>WordPress
+    </button>
+    <div class="collapse" id="instr-wordpress">
+      <div class="card card-body text-dark">
+        <p>Paste the script tag into a Text/HTML widget or within your theme to activate the widget site-wide.</p>
+      </div>
+    </div>
+
+    <!-- Squarespace -->
+    <button class="btn text-white" style="background-color:#000000" data-bs-toggle="collapse" data-bs-target="#instr-squarespace" aria-expanded="false" aria-controls="instr-squarespace">
+      <i class="fa-brands fa-squarespace me-2"></i>Squarespace
+    </button>
+    <div class="collapse" id="instr-squarespace">
+      <div class="card card-body text-dark">
+        <p>Insert the embed code into a Code Block on your Squarespace page.</p>
+      </div>
+    </div>
+
+    <!-- Webflow -->
+    <button class="btn text-white" style="background-color:#4353FF" data-bs-toggle="collapse" data-bs-target="#instr-webflow" aria-expanded="false" aria-controls="instr-webflow">
+      <i class="fa-brands fa-webflow me-2"></i>Webflow
+    </button>
+    <div class="collapse" id="instr-webflow">
+      <div class="card card-body text-dark">
+        <p>Add an Embed element to your Webflow project and include the script snippet.</p>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add integration buttons section with collapsible instructions
- include integrations partial at bottom of dashboard
- test presence and order of integration buttons

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a791be0488332adf666346147ca51