### PR TITLE
Enhance specials list with active glow and controls

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -2,6 +2,7 @@ from django.template.loader import render_to_string
 from django.test import TestCase
 
 from .forms import SpecialForm
+from .models import Special
 
 
 class SpecialFormTemplateTests(TestCase):
@@ -68,3 +69,31 @@ class DashboardTemplateTests(TestCase):
     def test_connections_partial_included(self):
         html = render_to_string("app/dashboard.html", {"specials": [], "form": None})
         self.assertIn("integration-connections", html)
+
+
+class SpecialsListTemplateTests(TestCase):
+    def render(self, specials):
+        return render_to_string("app/partials/specials_list.html", {"specials": specials})
+
+    def test_management_buttons_present(self):
+        sp = Special(title="Test")
+        html = self.render([sp])
+        self.assertIn("Delete", html)
+        self.assertIn("Sold Out", html)
+        self.assertIn("Make Active", html)
+        self.assertIn("Edit", html)
+
+    def test_published_special_has_glow(self):
+        live = Special(title="Live", published=True)
+        draft = Special(title="Draft", published=False)
+        html = self.render([live, draft])
+        self.assertEqual(html.count("special-live"), 1)
+
+    def test_uses_grid_layout(self):
+        sp = Special(title="Grid")
+        html = self.render([sp])
+        self.assertIn("row-cols", html)
+
+    def test_placeholder_cards_render_when_empty(self):
+        html = self.render([])
+        self.assertIn("Sample Special", html)

--- a/static/style.css
+++ b/static/style.css
@@ -75,8 +75,11 @@
   [data-animate="lift"]{opacity:0; transform:translateY(8px); transition:opacity .6s ease, transform .6s ease}
   [data-animate="pop"]{transform:translateY(0)}
   [data-animate="float"]{opacity:0; transform:translateY(10px)}
-  .inview{opacity:1!important; transform:none!important}
+.inview{opacity:1!important; transform:none!important}
 }
+
+/* Active specials */
+.special-live{box-shadow:0 0 0 2px var(--teal),0 0 8px var(--teal);}
 
 
 /* ================================ */

--- a/templates/app/partials/specials_list.html
+++ b/templates/app/partials/specials_list.html
@@ -1,19 +1,65 @@
-<div class="row g-3">
+<div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-3">
   {% for sp in specials %}
-    <div class="col-md-6 col-lg-4">
-      <div class="card h-100 border-0 shadow-sm">
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm {% if sp.published %}special-live{% endif %}">
         {% if sp.image %}<img src="{{ sp.image.url }}" class="card-img-top object-cover" style="max-height:160px;">{% endif %}
-        <div class="card-body">
+        <div class="card-body p-2">
           <h3 class="h6 mb-1">{{ sp.title }}</h3>
           <p class="small text-secondary">{{ sp.description|truncatechars:100 }}</p>
-          <div class="d-flex gap-2">
+          <div class="d-flex flex-wrap gap-1">
             <a href="" class="btn btn-outline-light btn-sm">Edit</a>
+            <a href="" class="btn btn-outline-warning btn-sm">Sold Out</a>
+            <a href="" class="btn btn-outline-success btn-sm">Make Active</a>
             <a href="" class="btn btn-outline-danger btn-sm">Delete</a>
           </div>
         </div>
       </div>
     </div>
   {% empty %}
-    <div class="col-12 text-secondary">No specials yet.</div>
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 1</h3>
+          <p class="small text-secondary">A tasty placeholder item.</p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-outline-light btn-sm">Edit</a>
+            <a href="#" class="btn btn-outline-warning btn-sm">Sold Out</a>
+            <a href="#" class="btn btn-outline-success btn-sm">Make Active</a>
+            <a href="#" class="btn btn-outline-danger btn-sm">Delete</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 2</h3>
+          <p class="small text-secondary">Another delicious placeholder.</p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-outline-light btn-sm">Edit</a>
+            <a href="#" class="btn btn-outline-warning btn-sm">Sold Out</a>
+            <a href="#" class="btn btn-outline-success btn-sm">Make Active</a>
+            <a href="#" class="btn btn-outline-danger btn-sm">Delete</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 3</h3>
+          <p class="small text-secondary">Fill in your own amazing deal.</p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-outline-light btn-sm">Edit</a>
+            <a href="#" class="btn btn-outline-warning btn-sm">Sold Out</a>
+            <a href="#" class="btn btn-outline-success btn-sm">Make Active</a>
+            <a href="#" class="btn btn-outline-danger btn-sm">Delete</a>
+          </div>
+        </div>
+      </div>
+    </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- render specials list as a responsive grid of mini cards
- add management buttons for Edit, Sold Out, Make Active and Delete
- highlight published specials with a glowing border
- show sample placeholder cards when no specials exist

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689a7c122e6883329dcc236653ce0be4