### PR TITLE
Fix preview form population and publish flow

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -148,7 +148,7 @@ def special_preview(request, pk):
     ctx = {
         "special": sp,
         "form": form,
-        "action_url": reverse("special_preview", args=[sp.pk]),
+        "publish_url": reverse("special_publish", args=[sp.pk]),
     }
     return render(request, "app/special_preview.html", ctx)
 

--- a/static/appertivo.js
+++ b/static/appertivo.js
@@ -77,28 +77,22 @@
   // -------------------------------
   // ---------- CTA segmented control (robust, no aria-label dependency) ----------
 function bindCTA(root){
-  // scope to the current form
   const form = root.closest?.('form') || root.querySelector?.('#special-form') || root;
   if (!form) return;
 
-  // find any labels that declare a CTA type
   const labels = form.querySelectorAll('label[data-cta]');
   if (!labels.length) return;
 
-  // find radios that correspond to those labels
   const radios = form.querySelectorAll('input[type="radio"].btn-check');
   if (!radios.length) return;
 
-  // guard: avoid rebinding twice on this form
   if (form.dataset.ctaBound === '1') return;
   form.dataset.ctaBound = '1';
 
-  // build groups map from radio values: "order" -> #group-order, "mobile_order" -> #group-mobile_order
   const groups = {};
   const inputs = {};
-  const getGroupId = (val) => `group-${val}`; // ids in template already match this scheme
+  const getGroupId = (val) => `group-${val}`;
 
-  // prime groups/inputs (only for values that actually exist)
   radios.forEach(r => {
     const id = getGroupId(r.value);
     const g = form.querySelector(`#${CSS.escape(id)}`);
@@ -108,8 +102,7 @@ function bindCTA(root){
     }
   });
 
-  function showGroup(key){
-    // hide/disable all
+  function showGroup(key, focus=false){
     Object.keys(groups).forEach(k => {
       const g = groups[k], inp = inputs[k];
       if (!g) return;
@@ -118,11 +111,9 @@ function bindCTA(root){
       if (inp){ inp.disabled = true; inp.required = false; }
     });
 
-    // active label look
     labels.forEach(l => l.classList.remove('btn-orange'));
     form.querySelector(`label[data-cta="${key}"]`)?.classList.add('btn-orange');
 
-    // show/enable selected
     const g = groups[key], inp = inputs[key];
     if (g){
       g.classList.remove('d-none');
@@ -133,17 +124,16 @@ function bindCTA(root){
       if (inp){
         inp.disabled = false;
         inp.required = true;
-        setTimeout(()=>{ inp.focus(); inp.select?.(); }, 50);
+        if (focus){ setTimeout(()=>{ inp.focus(); inp.select?.(); }, 50); }
       }
     }
   }
 
-  function sync(){
+  function sync(focus=false){
     const r = Array.from(radios).find(x => x.checked);
-    if (r) showGroup(r.value);
+    if (r) showGroup(r.value, focus);
   }
 
-  // click on label -> check radio -> change -> sync
   labels.forEach(l => {
     l.addEventListener('click', () => {
       const val = l.getAttribute('data-cta');
@@ -152,17 +142,14 @@ function bindCTA(root){
     });
   });
 
-  // change on any radio
-  radios.forEach(r => r.addEventListener('change', sync));
+  radios.forEach(r => r.addEventListener('change', ()=>sync(true)));
 
-  // pick first available option if none selected
   if (![...radios].some(r => r.checked)) {
-    const first = [...radios].find(r => groups[r.value]); // only if we have a matching group
+    const first = [...radios].find(r => groups[r.value]);
     if (first) first.checked = true;
   }
 
-  // initial paint
-  sync();
+  sync(false);
 }
 
 
@@ -184,6 +171,7 @@ function bindCTA(root){
         btn.textContent = input.value || btn.dataset.placeholder;
         validate();
       });
+      btn.textContent = input.value || btn.textContent;
       btn.dataset.boundPicker = '1';
     }
     attach(start, startBtn);
@@ -271,6 +259,10 @@ function bindCTA(root){
       img.classList.add('d-none');
       reset.hidden = true;
     });
+
+    if (img.src && !img.classList.contains('d-none')) {
+      reset.hidden = false;
+    }
 
     dz.dataset.imgBound = '1';
   }

--- a/templates/app/partials/special_form.html
+++ b/templates/app/partials/special_form.html
@@ -103,12 +103,6 @@
   <hr class="border-ink-700 my-4">
   <div class="row g-3">
     <div class="col-md-12">
-      {% if special and special.image %}
-        <div class="mb-2 text-center">
-          <img src="{{ special.image }}" alt="{{ special.title }}" class="img-fluid rounded" style="max-height:200px;">
-        </div>
-      {% endif %}
-
       <div class="border rounded-3 p-3 widget-frame position-relative" id="image-dropzone">
         <div class="d-flex align-items-center justify-content-between">
           <div>
@@ -117,14 +111,14 @@
           </div>
           <div class="d-flex gap-2">
             <label class="btn btn-teal btn-sm mb-0" for="id_image">Choose</label>
-            <button class="btn btn-outline-ink btn-sm" type="button" id="image-reset" hidden>Reset</button>
+            <button class="btn btn-outline-ink btn-sm" type="button" id="image-reset" {% if not special or not special.image %}hidden{% endif %}>Reset</button>
           </div>
         </div>
 
         {{ form.image_file|add_class:"form-control d-none"|attr:"accept:image/png,image/jpeg"|attr:"id:id_image" }}
 
         <div class="ratio ratio-16x9 mt-3 rounded overflow-hidden bg-dark-subtle" id="image-preview-shell" aria-live="polite">
-          <img id="image-preview" class="w-100 h-100 object-cover d-none" alt="Image preview">
+          <img id="image-preview" class="w-100 h-100 object-cover{% if not special or not special.image %} d-none{% endif %}" alt="Image preview"{% if special and special.image %} src="{{ special.image }}"{% endif %}>
         </div>
       </div>
       {% if form.image_file.errors %}
@@ -146,7 +140,7 @@
             name="{{ form.cta_choices.name }}"
             id="cta_{{ forloop.counter }}"
             value="{{ val }}"
-            {% if form.cta_choices.value == val %}checked{% endif %}
+            {% if form.cta_choices.value and val in form.cta_choices.value %}checked{% endif %}
           >
           <label class="btn btn-outline-ink" for="cta_{{ forloop.counter }}" data-cta="{{ val }}">
             {{ label }}
@@ -215,7 +209,7 @@ function bindCTA(root){
       inputs[r.value] = g.querySelector('input,textarea,select');
     }
   });
-  function showGroup(key){
+  function showGroup(key, focus=false){
     Object.keys(groups).forEach(k => {
       const g = groups[k], inp = inputs[k];
       g.classList.add('d-none');
@@ -234,13 +228,13 @@ function bindCTA(root){
       if(inp){
         inp.disabled = false;
         inp.required = true;
-        setTimeout(()=>{inp.focus(); inp.select && inp.select();},50);
+        if(focus){ setTimeout(()=>{inp.focus(); inp.select && inp.select();},50); }
       }
     }
   }
-  function sync(){
+  function sync(focus=false){
     const r = Array.from(radios).find(x => x.checked);
-    if(r) showGroup(r.value);
+    if(r) showGroup(r.value, focus);
   }
   labels.forEach(l => {
     l.addEventListener('click', () => {
@@ -249,12 +243,12 @@ function bindCTA(root){
       if(r){ r.checked = true; r.dispatchEvent(new Event('change', {bubbles:true})); }
     });
   });
-  radios.forEach(r => r.addEventListener('change', sync));
+  radios.forEach(r => r.addEventListener('change', ()=>sync(true)));
   if(!Array.from(radios).some(r => r.checked)){
     const first = Array.from(radios).find(r => groups[r.value]);
     if(first) first.checked = true;
   }
-  sync();
+  sync(false);
 }
 
 document.addEventListener('DOMContentLoaded', function(){

--- a/templates/app/special_preview.html
+++ b/templates/app/special_preview.html
@@ -37,7 +37,7 @@
 
       {# Render the same form partial but in "embedded" mode #}
       <div class="special-form-embedded bg-light p-5 rounded">
-        {% include 'app/partials/special_form.html' with form=form action_url=action_url submit_label='Update' %}
+        {% include 'app/partials/special_form.html' with form=form action_url=publish_url submit_label='Publish' %}
       </div>
     </div>
   </div>
@@ -46,6 +46,7 @@
 <script>
 // After the form partial renders, rewire its Refresh button to hit this page's widget fragment.
 document.addEventListener('DOMContentLoaded', () => {
+  window.scrollTo(0,0);
   const btn = document.getElementById('btn-refresh-preview');
   if (btn) {
     btn.setAttribute('hx-get', "{% url 'special_preview' special.pk %}?fragment=widget");


### PR DESCRIPTION
## Summary
- Show previously selected dates, CTA choice, and image in preview form
- Keep preview page at top and change action button to publish
- Ensure existing image renders in dropzone and CTA radios handle list values

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ba489f2b08332834395b1054d749d