### PR TITLE
Externalize connection page styles

### DIFF
--- a/app/specialwidget/static/specialwidget/css/style.css
+++ b/app/specialwidget/static/specialwidget/css/style.css
@@ -6488,3 +6488,76 @@ input[type=number] {
 .slider-cover-dots .splide__pagination {
   transform: translate(-50%, -40px) !important;
 }
+body.connection {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #B993D6 0%, #49475B 100%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color: #f8f9fa;
+  text-align: center;
+  padding: 20px;
+}
+
+body.connection .container {
+  max-width: 600px;
+  background: rgba(20, 8, 14, 0.6);
+  padding: 40px 30px;
+  border-radius: 15px;
+  box-shadow: 0 10px 30px rgba(73, 71, 91, 0.6);
+}
+
+body.connection h1 {
+  font-size: 2.5rem;
+  margin-bottom: 15px;
+  color: #f08000;
+  font-weight: 700;
+}
+
+body.connection .tagline {
+  font-size: 1.4rem;
+  color: #58B09C;
+  margin-bottom: 20px;
+  font-weight: 500;
+}
+
+body.connection ul {
+  text-align: left;
+  font-size: 1.05rem;
+  color: #dcdcdc;
+  margin-bottom: 30px;
+  padding-left: 1.2em;
+}
+
+body.connection ul li {
+  margin-bottom: 0.7em;
+}
+
+body.connection .cta {
+  margin: 25px 0 10px 0;
+  font-weight: bold;
+  color: #f8f9fa;
+  background: #f08000;
+  padding: 0.7em 1.3em;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 14px rgba(240, 128, 0, 0.2);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background 0.2s;
+}
+
+body.connection .cta:hover {
+  background: #ff9900;
+}
+
+body.connection .footer {
+  font-size: 0.95rem;
+  color: #58B09C;
+  margin-top: 25px;
+}

--- a/app/specialwidget/templates/connection.html
+++ b/app/specialwidget/templates/connection.html
@@ -1,0 +1,39 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Appertivo — Instantly Share Your Restaurant Specials</title>
+  <meta name="description" content="Appertivo is the easiest way for restaurants to post daily specials, engage customers, and boost sales — all without logins or technical hassle." />
+  <meta property="og:title" content="Appertivo — Instantly Share Your Restaurant Specials" />
+  <meta property="og:description" content="Add a special, see it live. Appertivo lets you update and display your daily specials with a simple dashboard, live preview, and a copy-paste widget for your website." />
+  <meta property="og:image" content="https://yourdomain.com/og-image.png" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://appertivo.com/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Appertivo — Instantly Share Your Restaurant Specials" />
+  <meta name="twitter:description" content="Let your customers know what’s special today. Easy, mobile-first, and no logins required." />
+  <meta name="twitter:image" content="https://yourdomain.com/og-image.png" />
+  <link rel="stylesheet" href="{% static 'specialwidget/css/style.css' %}">
+</head>
+<body class="connection">
+  <div class="container" role="main">
+    <h1>Appertivo is Coming Soon</h1>
+    <div class="tagline">Add a Special. See It Live. Delight Your Customers.</div>
+    <ul>
+      <li><strong>Brain-dead simple:</strong> Add today’s special with a photo, short description, and optional dates—right from your phone. No logins required.</li>
+      <li><strong>Live preview:</strong> See exactly how your special will look before publishing.</li>
+      <li><strong>Easy install:</strong> Copy a widget code or send it to your web developer. Works with WordPress, Shopify, Wix, and more.</li>
+      <li><strong>Boost sales:</strong> Customers see your latest special on your site, with a direct link to “Order Now.”</li>
+      <li><strong>Mobile-first dashboard:</strong> Update specials from your phone, on the go—even with QR code access on your counter.</li>
+      <li><strong>Customize your widget:</strong> Match your colors, choose position, and connect your online ordering provider.</li>
+    </ul>
+    <a class="cta" href="mailto:hello@appertivo.com?subject=Early%20Access%20Request">Get Early Access</a>
+    <div class="footer">
+      Thank you for your patience &amp; support.<br>
+      <span style="font-size:0.9em;">Free for early adopters • Powered by Django &amp; HTMX</span>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add connection page template served from Django and referencing shared styles
- move inline connection styles into global stylesheet

## Testing
- `cd app && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb8e1a77483329e061dc4bec6b4b3