### PR TITLE
Move special creation form to dedicated page

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -113,7 +113,7 @@ class ConnectionPartialTests(TestCase):
 
 class DashboardTemplateTests(TestCase):
     def test_connections_partial_included(self):
-        html = render_to_string("app/dashboard.html", {"specials": [], "form": None})
+        html = render_to_string("app/dashboard.html", {"specials": []})
         self.assertIn("integration-connections", html)
 
 
@@ -124,8 +124,8 @@ class SpecialsListTemplateTests(TestCase):
     def test_management_buttons_present(self):
         sp = Special(title="Test")
         html = self.render([sp])
-        self.assertIn("bi-pencil", html)
-        self.assertIn("bi-x-lg", html)
+        self.assertIn("fa-pen", html)
+        self.assertIn("fa-circle-minus", html)
         self.assertIn("Sold Out", html)
         self.assertIn("Make Active", html)
 
@@ -190,6 +190,15 @@ class SpecialWorkflowTests(TestCase):
         data = self._valid_data()
         self.client.post(reverse("special_create"), data)
         self.assertFalse(mock_enhance.called)
+
+    def test_get_create_page_displays_form(self):
+        response = self.client.get(reverse("special_create"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="special-form"')
+
+    def test_dashboard_has_no_create_form(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertNotContains(response, 'id="special-form"')
 
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -22,17 +22,9 @@ from dotenv import load_dotenv
 load_dotenv()  # take environment variables
 
 def dashboard(request):
-    """
-    Renders the main dashboard: 
-    - full-page list of specials 
-    - form is included via HTMX fragment
-    """
+    """Renders the main dashboard."""
     specials = Special.objects.order_by("-start_date", "-created_at")
-    form     = SpecialForm()
-    return render(request, "app/dashboard.html", {
-        "specials": specials,
-        "form": form,
-    })
+    return render(request, "app/dashboard.html", {"specials": specials})
 
 
 
@@ -139,7 +131,7 @@ def specials_api(request):
 
 
 def special_create(request):
-    user_profile = getattr(request, 'user_profile', None)
+    user_profile = getattr(request, "user_profile", None)
 
     if request.method == "POST":
         form = SpecialForm(request.POST, request.FILES)
@@ -150,10 +142,11 @@ def special_create(request):
             special.save()
             if form.cleaned_data.get("ai_enhance"):
                 enhance_special_content(special)
-            return redirect("special_preview", pk=special.pk, form=form)
-        specials = Special.objects.order_by("-start_date", "-created_at")
-        return render(request, "app/dashboard.html", {"specials": specials, "form": form})
-    return redirect("dashboard")
+            return redirect("special_preview", pk=special.pk)
+        return render(request, "app/special_step1.html", {"form": form})
+
+    form = SpecialForm()
+    return render(request, "app/special_step1.html", {"form": form})
 
 
 def special_preview(request, pk):

--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -112,48 +112,16 @@
     </div>
   </section>
 
-  <!-- Form zone -->
-  <section class="container pb-6">
-    <div class="row justify-content-center">
-      <div class="col-lg-5">
-        <div class="card rounded-4 p-4" data-animate="reveal" style="box-shadow: 0 0 20px 5px #B993D6;">
-          <div class="card-body p-0 border-0">
-           
-        {% include 'app/partials/special_form.html' %}
+    <section class="container pb-6">
+      <div class="row">
+        <div class="col-md-12 mt-5">
+          {% include 'app/partials/connection.html' %}
+        </div>
+        <div class="col-md-12 mt-5">
+          {% include 'app/partials/specials_list.html' %}
         </div>
       </div>
-    </div>
-    <div class="col-lg-7 p-5 display-6">
-      <p class="fs-5 brand-purple mx-auto" style="max-width: 700px; line-height: 1.7;">
-  <strong>Specials</strong> are one of the most effective ways for restaurants to 
-  <span class="font-purple fw-semibold">attract attention</span>, 
-  <span class="font-purple fw-semibold">drive foot traffic</span>, and 
-  <span class="font-purple fw-semibold">boost sales</span>. Yet, many establishments 
-  struggle to promote their limited-time offers efficiently and consistently.
-</p>
-
-<p class="fs-5 text-light mx-auto" style="max-width: 700px; line-height: 1.7;">
-  <strong>Appertivo</strong> focuses on simplifying this process, empowering restaurant owners to 
-  quickly create, showcase, and manage their specials without technical headaches or time-consuming setups. 
-  In an industry where every moment counts, our tool provides the 
-  <span class="font-orange fw-bold">focus and automation</span> needed to turn daily specials into powerful marketing assets — helping restaurants 
-  <span class="font-orange fw-bold">stand out</span>, <span class="font-orange fw-bold">engage customers</span>, and 
-  <span class="font-orange fw-bold">grow revenue effortlessly</span>.
-</p>
-
-    </div>
-</div>
-    </div>
-
-      <div class="row">
-    <div class="col-md-12 mt-5">
-      {% include 'app/partials/connection.html' %}
-    </div>
-    <div class="col-md-12 mt-5">
-      {% include 'app/partials/specials_list.html' %}
-    </div>
-  </div>
-</section>
+    </section>
 
 
 {% endblock %}

--- a/templates/app/special_step1.html
+++ b/templates/app/special_step1.html
@@ -1,0 +1,9 @@
+{% extends 'app/base.html' %}
+{% block title %}Create a Special · Appertivo{% endblock %}
+{% block content %}
+<div class="container min-vh-100 d-flex justify-content-center align-items-center">
+  <div class="w-100" style="max-width: 540px;">
+    {% include 'app/partials/special_form.html' %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Move special creation form out of dashboard into new dedicated page
- Update `special_create` view to render the new page and handle POST
- Remove form from dashboard and adjust tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f92dd51a48332b6b4c3df42fcd85d