### PR TITLE
Enable editing and deleting specials

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -261,3 +261,11 @@ def special_update(request, pk):
         },
         status=422,
     )
+
+
+@require_http_methods(["DELETE"])
+def special_delete(request, pk):
+    profile = getattr(request, "user_profile", None)
+    sp = get_object_or_404(Special, pk=pk, user_profile=profile)
+    sp.delete()
+    return HttpResponse(status=204)

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("specials/<int:pk>/preview/", views.special_preview, name="special_preview"),
     # urls.py
     path("specials/<int:pk>/update/", views.special_update, name="special_update"),
+    path("specials/<int:pk>/delete/", views.special_delete, name="special_delete"),
     path("specials/<int:pk>/publish/", views.special_publish, name="special_publish"),
     
     path("api/specials.js", views.specials_api, name="specials_api"),

--- a/templates/app/partials/specials_list.html
+++ b/templates/app/partials/specials_list.html
@@ -3,19 +3,24 @@
     <div class="col">
       <div class="card h-100 border-0 shadow-sm position-relative {% if sp.published %}special-live{% endif %}">
         {% if sp.image %}<img src="{{ sp.image }}" class="card-img-top object-cover" style="max-height:160px;">{% endif %}
-        <div class="position-absolute top-0 start-0 m-1">
-          <a href="" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="bi bi-pencil text-primary"></i></a>
-        </div>
-        <div class="position-absolute top-0 end-0 m-1">
-          <a href="" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="bi bi-x-lg text-danger"></i></a>
-        </div>
+          <div class="position-absolute top-0 start-0 m-1">
+            <a href="{% url 'special_preview' sp.pk %}" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="bi bi-pencil text-primary"></i></a>
+          </div>
+          <div class="position-absolute top-0 end-0 m-1">
+            <a hx-delete="{% url 'special_delete' sp.pk %}" hx-confirm="Delete this special?" hx-target="closest .col" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="bi bi-x-lg text-danger"></i></a>
+          </div>
         <div class="card-body p-2">
           <h3 class="h6 mb-1">{{ sp.title }}</h3>
           <p class="small text-secondary mb-1">{{ sp.description|truncatechars:100 }}</p>
           {% if sp.end_date %}
-          <p class="small text-secondary mb-2">
-            {% if sp.is_expired %}Expired{% else %}Active{% endif %}: {{ sp.end_date|date:"Y-m-d" }}
-          </p>
+            <p class="small mb-2">
+              {% if sp.is_expired %}
+              <span class="badge bg-secondary me-1">Expired</span>
+              {% else %}
+              <span class="badge bg-teal text-dark me-1">Active</span>
+              {% endif %}
+              <span class="text-secondary">{{ sp.end_date|date:"Y-m-d" }}</span>
+            </p>
           {% endif %}
           <div class="d-flex flex-wrap gap-1">
             {% if not sp.is_expired %}<a href="" class="btn btn-orange btn-sm text-white">Sold Out</a>{% endif %}
@@ -42,7 +47,7 @@
         <div class="card-body p-2">
           <h3 class="h6 mb-1">Sample Special 1</h3>
           <p class="small text-secondary mb-1">A tasty placeholder item.</p>
-          <p class="small text-secondary mb-2">Expired: 2024-01-01</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
           <div class="d-flex flex-wrap gap-1">
             <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
             <a href="#" class="btn btn-teal btn-sm">Make Active</a>
@@ -62,7 +67,7 @@
         <div class="card-body p-2">
           <h3 class="h6 mb-1">Sample Special 2</h3>
           <p class="small text-secondary mb-1">Another delicious placeholder.</p>
-          <p class="small text-secondary mb-2">Expired: 2024-01-01</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
           <div class="d-flex flex-wrap gap-1">
             <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
             <a href="#" class="btn btn-teal btn-sm">Make Active</a>
@@ -82,7 +87,7 @@
         <div class="card-body p-2">
           <h3 class="h6 mb-1">Sample Special 3</h3>
           <p class="small text-secondary mb-1">Fill in your own amazing deal.</p>
-          <p class="small text-secondary mb-2">Expired: 2024-01-01</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
           <div class="d-flex flex-wrap gap-1">
             <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
             <a href="#" class="btn btn-teal btn-sm">Make Active</a>


### PR DESCRIPTION
## Summary
- Link specials list edit button to preview page for full-form editing
- Add HTMX-powered delete with confirmation and server-side removal
- Show Active/Expired status via teal and gray badges

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_689fa3e36f688332a7abbfbfae19c324