### PR TITLE
Revamp My Specials page with stats and integrations

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -229,8 +229,25 @@ def my_specials(request):
     if not profile:
         return redirect("home")
 
-    specials = Special.objects.filter(user_profile=profile).order_by('-created_at')
-    return render(request, "app/my_specials.html", {"specials": specials})
+    specials = Special.objects.filter(
+        user_profile=profile
+    ).order_by("-created_at")
+    stats = {
+        "opens": sum(sp.analytics.opens for sp in specials),
+        "cta_clicks": sum(sp.analytics.cta_clicks for sp in specials),
+        "email_signups": sum(
+            sp.analytics.email_signups for sp in specials
+        ),
+    }
+    subscribers = EmailSignup.objects.filter(
+        user_profile=profile
+    ).order_by("-created_at")
+    context = {
+        "specials": specials,
+        "stats": stats,
+        "subscribers": subscribers,
+    }
+    return render(request, "app/my_specials.html", context)
 
 @require_POST
 def special_update(request, pk):

--- a/templates/app/my_specials.html
+++ b/templates/app/my_specials.html
@@ -1,13 +1,55 @@
 {% extends "app/base.html" %}
+{% load static %}
 {% block title %}My Specials{% endblock %}
 {% block content %}
-{% load static %}
-<div class="p-4">
+<div class="container py-4">
   <h2 class="h4 mb-3">My Specials</h2>
-  <div id="specials-list" hx-get="" hx-trigger="load" hx-target="#specials-list" hx-swap="innerHTML">
-    <div class="text-secondary">Loading…</div>
+  {% include "app/partials/specials_list.html" with specials=specials %}
+
+  <div class="card mt-4">
+    <div class="card-header">Stats</div>
+    <div class="card-body">
+      <div>Total Opens: {{ stats.opens }}</div>
+      <div>CTA Clicks: {{ stats.cta_clicks }}</div>
+      <div>Email Signups: {{ stats.email_signups }}</div>
+    </div>
+  </div>
+
+  <div class="card mt-4">
+    <div class="card-header">Email Subscribers</div>
+    <ul class="list-group list-group-flush">
+      {% for sub in subscribers %}
+      <li class="list-group-item">{{ sub.email }}</li>
+      {% empty %}
+      <li class="list-group-item text-secondary">No subscribers yet</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="card mt-4">
+    <div class="card-header">Billing</div>
+    <div class="card-body">
+      <p class="text-secondary mb-0">Coming soon.</p>
+    </div>
+  </div>
+
+  <div class="card mt-4">
+    <div class="card-header">Integrations</div>
+    <div class="card-body">
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="posIntegration">
+        <label class="form-check-label" for="posIntegration">POS Integration</label>
+      </div>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="websiteIntegration">
+        <label class="form-check-label" for="websiteIntegration">Website Integration</label>
+      </div>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="marketingIntegration">
+        <label class="form-check-label" for="marketingIntegration">Marketing Integration</label>
+      </div>
+    </div>
   </div>
 </div>
-
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Rework My Specials page to include specials list, aggregate stats, subscriber list, billing placeholder, and integration toggles.
- Compute aggregated analytics and gather subscriber data in view.
- Extend tests for My Specials page and align icon test with Bootstrap icons.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689fa54b914883328022fdbc3a4a3357