### PR TITLE
Restrict integrations to premium accounts

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
-from django.http import HttpResponse, HttpResponseBadRequest, QueryDict
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, QueryDict
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from profiles.models import UserProfile
@@ -236,6 +236,10 @@ def integrations_toggle(request, provider: str):
     HTMX endpoint to enable/disable an integration.
     Expects form or JSON field 'enabled' -> true/false.
     """
+    profile = getattr(request, "user_profile", None)
+    if not getattr(profile, "is_premium", False):
+        return HttpResponseForbidden("Upgrade to premium to access integrations")
+
     # Accept either form-encoded (hx-vals) or raw JSON
     enabled = None
     if request.content_type == "application/json":
@@ -267,6 +271,10 @@ def integrations_connect(request, provider: str):
     """
     A simple stub page (or start an OAuth flow).
     """
+    profile = getattr(request, "user_profile", None)
+    if not getattr(profile, "is_premium", False):
+        return HttpResponseForbidden("Upgrade to premium to access integrations")
+
     # For now just render a basic page or redirect to provider auth.
     # return redirect(external_oauth_url)
     return JsonResponse({"provider": provider, "action": "configure"})

--- a/templates/app/my_specials.html
+++ b/templates/app/my_specials.html
@@ -128,7 +128,12 @@
 
 
   <div class="card mt-4">
-    <div class="card-header">Integrations</div>
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span>Integrations</span>
+      {% if not request.user_profile.is_premium %}
+        <span class="badge bg-warning text-dark">Upgrade to unlock</span>
+      {% endif %}
+    </div>
     <div class="card-body">
       <p class="text-secondary">Connect platforms to auto-post specials, sync menus, and track conversions.</p>
 
@@ -148,7 +153,8 @@
                        {% if integration_status.uber_eats %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'uber_eats' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-uber">
                   {% if integration_status.uber_eats %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>
@@ -172,7 +178,8 @@
                        {% if integration_status.doordash %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'doordash' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-doordash">
                   {% if integration_status.doordash %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>
@@ -196,7 +203,8 @@
                        {% if integration_status.google %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'google' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-google">
                   {% if integration_status.google %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>
@@ -220,7 +228,8 @@
                        {% if integration_status.apple %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'apple' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-apple">
                   {% if integration_status.apple %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>
@@ -244,7 +253,8 @@
                        {% if integration_status.square %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'square' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-square">
                   {% if integration_status.square %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>
@@ -267,7 +277,8 @@
                        {% if integration_status.toast %}checked{% endif %}
                        hx-post="{% url 'integrations_toggle' 'toast' %}"
                        hx-trigger="change"
-                       hx-vals='{"enabled": this.checked}'>
+                       hx-vals='{"enabled": this.checked}'
+                       {% if not request.user_profile.is_premium %}disabled{% endif %}>
                 <label class="form-check-label small" for="int-toast">
                   {% if integration_status.toast %}<span class="text-success">Connected</span>{% else %}Off{% endif %}
                 </label>


### PR DESCRIPTION
## Summary
- gate integration toggle and connect endpoints behind premium subscription
- mark integrations section disabled for free users with an upgrade badge
- test premium vs free behavior for integration views and template

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689fca05cdec8332a684c043b3a47135