### PR TITLE
Honor next parameter on login and simplify login form

### DIFF
--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -25,3 +25,24 @@ class SignupEmailTests(TestCase):
         # Verification email should be sent
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("verify", mail.outbox[0].body)
+
+
+class EmailLoginViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="login@example.com", email="login@example.com", password="password123"
+        )
+
+    def test_next_query_parameter_redirects(self):
+        next_url = reverse("profile")
+        response = self.client.post(
+            f"{reverse('login')}?next={next_url}",
+            {"username": "login@example.com", "password": "password123"},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, next_url)
+
+    def test_login_template_is_minimal(self):
+        response = self.client.get(reverse("login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "navbar")

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -11,7 +11,7 @@ from django.db.models import Q
 from django.urls import reverse
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.utils.http import urlsafe_base64_decode
+from django.utils.http import urlsafe_base64_decode, url_has_allowed_host_and_scheme
 from django.contrib.auth.tokens import default_token_generator
 from .models import UserProfile
 from .forms import SignUpForm, EmailAuthenticationForm
@@ -72,6 +72,17 @@ class EmailLoginView(LoginView):
         if not remember:
             self.request.session.set_expiry(0)
         return super().form_valid(form)
+
+    def get_success_url(self):
+        """Redirect to `next` if provided and safe."""
+        redirect_to = self.request.POST.get(self.redirect_field_name) or self.request.GET.get(
+            self.redirect_field_name
+        )
+        if redirect_to and url_has_allowed_host_and_scheme(
+            redirect_to, allowed_hosts={self.request.get_host()}
+        ):
+            return redirect_to
+        return super().get_success_url()
 
 
 def signup(request):

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -9,25 +9,6 @@
   <link rel="stylesheet" href="{% static 'style.css' %}">
 </head>
 <body class="auth-body">
-<nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
-  <div class="container">
-    <a class="navbar-brand" href="{% url 'dashboard' %}">Appertivo</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav ms-auto">
-        {% if request.user.is_authenticated %}
-          <li class="nav-item"><a class="nav-link" href="{% url 'my_specials' %}">My Specials</a></li>
-          <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
-        {% else %}
-          <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
-        {% endif %}
-      </ul>
-    </div>
-  </div>
-</nav>
-
 <div class="container col-lg-4 col-md-6 col-sm-10 mt-5">
   <h2 class="mb-4 text-center brand-purple">Login</h2>
   <form method="post">
@@ -47,6 +28,9 @@
       {{ form.remember_me }}
       <label class="form-check-label" for="{{ form.remember_me.id_for_label }}">Remember me</label>
     </div>
+    {% if next %}
+    <input type="hidden" name="next" value="{{ next }}">
+    {% endif %}
     <button type="submit" class="btn brand-orange w-100">Login</button>
   </form>
   <div class="mt-3 text-center">


### PR DESCRIPTION
## Summary
- Redirect authenticated users to their intended page when a `next` query string is supplied
- Streamline login template by removing site navigation and handling `next`
- Test `next` handling and ensure login page renders without navigation elements

## Testing
- `python manage.py test profiles`
- `python manage.py test` *(fails: Reverse for 'special_preview' with arguments '(None,)' not found; MySpecialsTemplateTests return 302)*

------
https://chatgpt.com/codex/tasks/task_e_689fca06ab4c83328f23b5a6e4c99d29