### PR TITLE
Use production domain for widget scripts

### DIFF
--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -81,7 +81,7 @@
                     // optional: inlineWidth: '100%', inlineMaxWidth: '520px'
                   };
                 </script>
-                <script src="http://127.0.0.1:8000/appertivo-widget.js?restaurant=13&special=83"></script>
+                <script src="https://appertivo.com/appertivo-widget.js?restaurant=13&special=83"></script>
             </div>
           </div>
         </div>

--- a/templates/app/partials/special_preview.html
+++ b/templates/app/partials/special_preview.html
@@ -18,7 +18,7 @@
               // optional: inlineWidth: '100%', inlineMaxWidth: '520px'
             };
           </script>
-          <script src="http://127.0.0.1:8000/appertivo-widget.js?restaurant=13&special={{ special.pk }}"></script>
+          <script src="https://appertivo.com/appertivo-widget.js?restaurant=13&special={{ special.pk }}"></script>
         </div>
       </div>
     </div>

--- a/templates/app/special_preview.html
+++ b/templates/app/special_preview.html
@@ -34,7 +34,7 @@
                     // optional: inlineWidth: '100%', inlineMaxWidth: '520px'
                   };
                 </script>
-                <script src="http://127.0.0.1:8000/appertivo-widget.js?restaurant=13&special={{ special.pk }}"></script>
+                <script src="https://appertivo.com/appertivo-widget.js?restaurant=13&special={{ special.pk }}"></script>
             </div>
           </div>
           </div>


### PR DESCRIPTION
## Summary
- replace localhost widget URLs with https://appertivo.com

## Testing
- `python manage.py test` *(not run: user requested to skip)*

------
https://chatgpt.com/codex/tasks/task_e_68a10db351c0833281998d793fc16272