### PR TITLE
Align auth forms with dashboard styling

### DIFF
--- a/app/specialwidget/templates/account/login.html
+++ b/app/specialwidget/templates/account/login.html
@@ -9,7 +9,8 @@
 
 {% block content %}
 <div class="d-flex align-items-center justify-content-center mx-auto rounded shadow" style="width: 21rem;margin-top:10px;">
-  <div id="inactive-{{ data.id }}"class="border row bg-light p-3 w-100 rounded shadow" style="position:relative;">
+  <div id="inactive-{{ data.id }}" class="border row p-3 w-100 rounded shadow"
+       style="position:relative;background-image: linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);">
 
 {% get_providers as socialaccount_providers %}
 
@@ -41,7 +42,9 @@ of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
   
-  <button class="primaryAction btn btn-lg bg-primary text-white" type="submit">{% trans "Sign In" %}</button><br/><br/>
+  <button class="primaryAction btn btn-lg border w-100 text-white"
+          style="background-color:#f08000; background-image: repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 1px, transparent 1px, transparent 6px); background-size: 8px 8px;"
+          type="submit">{% trans "Sign In" %}</button><br/><br/>
   <small><a class="button secondaryAction mt-2 " href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a></small>
 </form>
 </div></div>

--- a/app/specialwidget/templates/account/signup.html
+++ b/app/specialwidget/templates/account/signup.html
@@ -9,7 +9,8 @@
 
 {% block content %}
 <div class="d-flex align-items-center justify-content-center mx-auto rounded shadow" style="width: 21rem;margin-top:10px;">
-  <div id="inactive-{{ data.id }}"class="border row bg-light p-3 w-100 rounded shadow" style="position:relative;">
+  <div id="inactive-{{ data.id }}" class="border row p-3 w-100 rounded shadow"
+       style="position:relative;background-image: linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);">
 
 
 <h1>{% trans "Sign Up" %}</h1>
@@ -22,7 +23,8 @@
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
-  <button class="btn btn-lg border w-100 text-white" type="submit" style="background-color:#b5aee4; background-image: repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 1px, transparent 1px, transparent 6px);">Signup</button>
+  <button class="btn btn-lg border w-100 text-white" type="submit"
+          style="background-color:#f08000; background-image: repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 1px, transparent 1px, transparent 6px); background-size: 8px 8px;">Signup</button>
 </form>
 </div></div>
 {% endblock %}

--- a/app/specialwidget/templates/registration/login.html
+++ b/app/specialwidget/templates/registration/login.html
@@ -6,8 +6,9 @@
 
 {% block content %}
 <div class="h-100 d-flex align-items-center justify-content-center">
-    <div class="py-auto text-center" style="margin-top:15%;">
-        <form method="post" class="border p-4 rounded shadow-sm">
+    <div class="col-md-3 p-5 text-center border shadow-sm rounded"
+         style="margin-top:15%;background-image: linear-gradient(to top, #a18cd1 0%, #fbc2eb 100%);">
+        <form method="post">
             {% csrf_token %}
             <div class="mb-3">
                 {{ form.username.label_tag }}
@@ -23,7 +24,8 @@
             <div class="mb-3 text-end">
                 <a href="{% url 'password_reset' %}">Forgot password?</a>
             </div>
-            <button type="submit" class="btn btn-lg bg-disabled shadow-sm px-4">
+            <button type="submit" class="btn btn-lg border shadow-sm px-4 text-white"
+                    style="background-color:#f08000; background-image: repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 1px, transparent 1px, transparent 6px); background-size: 8px 8px;">
                 <i class="fa-solid fa-egg text-black-50"> Continue</i>
             </button>
         </form>

--- a/app/specialwidget/templates/registration/register.html
+++ b/app/specialwidget/templates/registration/register.html
@@ -15,7 +15,10 @@
             {{ form.password.label_tag }}
             {{ form.password }}
           </div>
-          <button type="submit" class="btn btn-lg bg-light shadow-sm px-4 mt-3"><i class="fa-solid fa-egg text-black-50">  Continue</i></button>
+          <button type="submit" class="btn btn-lg border shadow-sm px-4 mt-3 text-white"
+                  style="background-color:#f08000; background-image: repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 1px, transparent 1px, transparent 6px); background-size: 8px 8px;">
+            <i class="fa-solid fa-egg text-black-50">  Continue</i>
+          </button>
         </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Match login and registration templates to dashboard aesthetics
- Reuse gradient panels and orange accent buttons for auth pages

## Testing
- `python app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a111788d3883328315a93bc2cc4079