### PR TITLE
Highlight first special on dashboard

### DIFF
--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -121,7 +121,7 @@
           {% include 'app/partials/connection.html' %}
         </div>
         <div class="col-md-12 mt-5">
-          {% include 'app/partials/specials_list.html' %}
+          {% include 'app/partials/specials_list.html' with dashboard_layout=True %}
         </div>
       </div>
     </section>

--- a/templates/app/partials/special_card.html
+++ b/templates/app/partials/special_card.html
@@ -1,0 +1,50 @@
+<div class="card h-100 border-0 shadow-sm position-relative {% if sp.published %}special-live{% endif %}">
+  {% if sp.image %}<img src="{{ sp.image }}" class="card-img-top object-cover" style="max-height:160px;">{% endif %}
+
+  {% if sp.pk %}
+    <div class="position-absolute top-0 start-0 m-1">
+      <a href="{% url 'special_preview' sp.pk %}" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="fa-solid fa-pen"></i></a>
+    </div>
+    <div class="position-absolute top-0 end-0 m-1">
+      <a hx-delete="{% url 'special_delete' sp.pk %}" hx-confirm="Delete this special?" hx-target="closest .col" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
+    </div>
+  {% else %}
+    <div class="position-absolute top-0 start-0 m-1">
+      <a href="#" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="bi bi-pencil"></i></a>
+    </div>
+    <div class="position-absolute top-0 end-0 m-1">
+      <a href="#" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="bi bi-x-lg"></i></a>
+    </div>
+  {% endif %}
+
+  <div class="card-body p-2" style="position: relative;">
+    <h3 class="h6 mb-1 px-2 pt-1">{{ sp.title }}</h3>
+    <p class="small text-secondary mb-1 px-2 pb-4">{{ sp.description|truncatechars:100 }}</p>
+    {% if not sp.pk %}
+    <div class="d-flex flex-wrap gap-1 px-2 pb-2">
+      <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
+    </div>
+    {% endif %}
+    {% if sp.end_date %}
+      <p class="small mb-2 align-items-end px-2" style="position: absolute; bottom: 0;">
+        {% if sp.is_expired %}
+          <span class="badge bg-secondary me-1">Expired:</span>
+        {% else %}
+          <span class="badge bg-teal text-white me-1">Active:</span>
+        {% endif %}
+        <span class="text-secondary">{{ sp.end_date|date:"Y-m-d" }}</span>
+      </p>
+    {% endif %}
+  </div>
+  {% if sp.pk %}
+  <div class="card-footer small text-secondary">
+    👁 {{ sp.analytics.opens|default:0 }} |
+    🔗 {{ sp.analytics.cta_clicks|default:0 }} |
+    ✉ {{ sp.analytics.email_signups|default:0 }}
+  </div>
+  {% else %}
+  <div class="card-footer small text-secondary">
+    👁 0 | 🔗 0 | ✉ 0
+  </div>
+  {% endif %}
+</div>

--- a/templates/app/partials/specials_list.html
+++ b/templates/app/partials/specials_list.html
@@ -1,56 +1,89 @@
+{% if dashboard_layout %}
+  {% if specials %}
+  <div class="row g-4">
+    <div class="col-12 col-lg-5">
+      {% with sp=specials|first %}
+        {% include 'app/partials/special_card.html' with sp=sp %}
+      {% endwith %}
+    </div>
+    <div class="col-12 col-lg-7">
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-2 row-cols-lg-2 g-4">
+        {% for sp in specials|slice:'1:' %}
+        <div class="col">
+          {% include 'app/partials/special_card.html' with sp=sp %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-4">
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm position-relative">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="position-absolute top-0 start-0 m-1">
+          <a href="#" class="btn btn-sm btn-purple" aria-label="Edit"><i class="fa-solid fa-pencil"></i></a>
+        </div>
+        <div class="position-absolute top-0 end-0 m-1">
+          <a href="#" class="btn btn-sm btn-outline-ink" aria-label="Delete"><i class="text-warning fa-solid fa-trash"></i></a>
+        </div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 1</h3>
+          <p class="small text-secondary mb-1">A tasty placeholder item.</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm position-relative">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="position-absolute top-0 start-0 m-1">
+          <a href="#" class="btn btn-sm btn-purple" aria-label="Edit"><i class="bi bi-pencil"></i></a>
+        </div>
+        <div class="position-absolute top-0 end-0 m-1">
+          <a href="#" class="btn btn-sm btn-outline-ink" aria-label="Delete"><i class="bi bi-x-lg"></i></a>
+        </div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 2</h3>
+          <p class="small text-secondary mb-1">Another delicious placeholder.</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
+            <a href="#" class="btn btn-teal btn-sm">Make Active</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm position-relative">
+        <div class="card-img-top bg-secondary" style="height:160px;"></div>
+        <div class="position-absolute top-0 start-0 m-1">
+          <a href="#" class="btn btn-sm btn-purple" aria-label="Edit"><i class="bi bi-pencil"></i></a>
+        </div>
+        <div class="position-absolute top-0 end-0 m-1">
+          <a href="#" class="btn btn-sm btn-outline-ink" aria-label="Delete"><i class="bi bi-x-lg"></i></a>
+        </div>
+        <div class="card-body p-2">
+          <h3 class="h6 mb-1">Sample Special 3</h3>
+          <p class="small text-secondary mb-1">Fill in your own amazing deal.</p>
+          <p class="small mb-2"><span class="badge bg-secondary me-1">Expired</span> <span class="text-secondary">2024-01-01</span></p>
+          <div class="d-flex flex-wrap gap-1">
+            <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
+            <a href="#" class="btn btn-teal btn-sm">Make Active</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+{% else %}
 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-4">
   {% for sp in specials %}
     <div class="col">
-      <div class="card h-100 border-0 shadow-sm position-relative {% if sp.published %}special-live{% endif %}">
-        {% if sp.image %}<img src="{{ sp.image }}" class="card-img-top object-cover" style="max-height:160px;">{% endif %}
-
-        {% if sp.pk %}
-          <div class="position-absolute top-0 start-0 m-1">
-            <a href="{% url 'special_preview' sp.pk %}" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="fa-solid fa-pen"></i></a>
-          </div>
-          <div class="position-absolute top-0 end-0 m-1">
-            <a hx-delete="{% url 'special_delete' sp.pk %}" hx-confirm="Delete this special?" hx-target="closest .col" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
-          </div>
-        {% else %}
-          <div class="position-absolute top-0 start-0 m-1">
-            <a href="#" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Edit"><i class="bi bi-pencil"></i></a>
-          </div>
-          <div class="position-absolute top-0 end-0 m-1">
-            <a href="#" class="btn btn-sm rounded-circle bg-light p-2 shadow" aria-label="Delete"><i class="bi bi-x-lg"></i></a>
-          </div>
-        {% endif %}
-
-        <div class="card-body p-2" style="position: relative;">
-          <h3 class="h6 mb-1 px-2 pt-1">{{ sp.title }}</h3>
-          <p class="small text-secondary mb-1 px-2 pb-4">{{ sp.description|truncatechars:100 }}</p>
-          {% if not sp.pk %}
-          <div class="d-flex flex-wrap gap-1 px-2 pb-2">
-            <a href="#" class="btn btn-orange btn-sm">Sold Out</a>
-          </div>
-          {% endif %}
-          {% if sp.end_date %}
-            <p class="small mb-2 align-items-end px-2" style="position: absolute; bottom: 0;">
-              {% if sp.is_expired %}
-                <span class="badge bg-secondary me-1">Expired:</span>
-              {% else %}
-                <span class="badge bg-teal text-white me-1">Active:</span>
-              {% endif %}
-              <span class="text-secondary">{{ sp.end_date|date:"Y-m-d" }}</span>
-            </p>
-          {% endif %}
-        </div>
-        {% if sp.pk %}
-        <div class="card-footer small text-secondary">
-          👁 {{ sp.analytics.opens|default:0 }} |
-          🔗 {{ sp.analytics.cta_clicks|default:0 }} |
-          ✉ {{ sp.analytics.email_signups|default:0 }}
-        </div>
-        {% else %}
-        <div class="card-footer small text-secondary">
-          👁 0 | 🔗 0 | ✉ 0
-        </div>
-        {% endif %}
-      </div>
+      {% include 'app/partials/special_card.html' with sp=sp %}
     </div>
   {% empty %}
     <div class="col">
@@ -114,3 +147,4 @@
     </div>
   {% endfor %}
 </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- feature first special in a larger column on dashboard
- extract card markup into reusable `special_card.html`
- support dashboard layout in `specials_list.html`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a11755c0988332ae34f4e72941b1b0