### PR TITLE
Add Google and Apple social login with django-allauth

### DIFF
--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -32,3 +32,15 @@ class SignupEmailTests(TestCase):
         # Verification email should be sent
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("verify", mail.outbox[0].body)
+
+
+class SocialLoginButtonTests(TestCase):
+    def test_login_page_contains_social_buttons(self):
+        response = self.client.get(reverse("login"))
+        self.assertContains(response, "/accounts/google/login/")
+        self.assertContains(response, "/accounts/apple/login/")
+
+    def test_signup_page_contains_social_buttons(self):
+        response = self.client.get(reverse("signup"))
+        self.assertContains(response, "/accounts/google/login/")
+        self.assertContains(response, "/accounts/apple/login/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-debug-toolbar  # for development debugging
 django-cors-headers # for handling CORS in development
 django-anymail[brevo]
 openai
+django-allauth

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -43,12 +43,18 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     'cloudinary',
     'django_extensions',
     'debug_toolbar',
     'corsheaders',
     'app.apps.AppConfig',
-    'profiles'
+    'profiles',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.apple',
 ]
 
 STRIPE_API_KEY = 'your_stripe_secret_key_here'
@@ -117,6 +123,16 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+SITE_ID = 1
+ACCOUNT_AUTHENTICATION_METHOD = 'email'
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
 
 
 # Internationalization

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
     path("accounts/password_reset/done/", auth_views.PasswordResetDoneView.as_view(template_name="registration/password_reset_done.html"), name="password_reset_done"),
     path("accounts/reset/<uidb64>/<token>/", auth_views.PasswordResetConfirmView.as_view(template_name="registration/password_reset_confirm.html"), name="password_reset_confirm"),
     path("accounts/reset/done/", auth_views.PasswordResetCompleteView.as_view(template_name="registration/password_reset_complete.html"), name="password_reset_complete"),
+    path("accounts/", include("allauth.urls")),
     path("profile/", profiles_views.profile_view, name="profile"),
 
     path("my-specials/", views.my_specials, name="my_specials"),

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,6 +1,6 @@
 {% extends 'app/base.html' %}
 {% block title %}Dashboard · Appertivo{% endblock %}
-{% load static %}
+{% load static socialaccount %}
 {% block content %}
 <div class="container col-lg-4 col-md-6 col-sm-10 mt-5 bg-white text-dark p-4 rounded-4 shadow-sm">
   <h2 class="mb-4 text-center text-dark">Login</h2>
@@ -26,6 +26,10 @@
     {% endif %}
     <button type="submit" class="btn brand-orange w-100">Login</button>
   </form>
+  <div class="mt-3">
+    <a href="{% provider_login_url 'google' %}" class="btn btn-outline-primary w-100 mb-2">Login with Google</a>
+    <a href="{% provider_login_url 'apple' %}" class="btn btn-outline-dark w-100">Login with Apple</a>
+  </div>
   <div class="mt-3 text-center">
     <a href="{% url 'password_reset' %}">Forgot password?</a> | <a href="{% url 'signup' %}">Sign up</a>
   </div>

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static socialaccount %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -31,6 +31,10 @@
     </div>
     <button type="submit" class="btn brand-orange w-100">Sign Up</button>
   </form>
+  <div class="mt-3">
+    <a href="{% provider_login_url 'google' %}" class="btn btn-outline-primary w-100 mb-2">Sign up with Google</a>
+    <a href="{% provider_login_url 'apple' %}" class="btn btn-outline-dark w-100">Sign up with Apple</a>
+  </div>
   <div class="mt-3 text-center">
     <a href="{% url 'login' %}">Already have an account? Login</a>
   </div>


### PR DESCRIPTION
## Summary
- integrate django-allauth for Google and Apple authentication
- expose provider login URLs and buttons on login and signup templates
- configure email-only authentication and add tests for social login buttons

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'allauth')*


------
https://chatgpt.com/codex/tasks/task_e_68a206cf0aac833281f794f181a047d9