### PR TITLE
Show active special stats on my specials page

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -6,6 +6,8 @@ from django.template.loader import render_to_string
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.utils import timezone
+from datetime import timedelta
 from .forms import SpecialForm
 from .models import Special, EmailSignup, Integration
 from .integrations import google
@@ -355,6 +357,17 @@ class MySpecialsTemplateTests(TestCase):
     def test_page_has_billing_section(self):
         response = self._get()
         self.assertContains(response, "Billing")
+
+    def test_page_shows_active_special_stats(self):
+        self.special1.published = True
+        self.special1.end_date = timezone.localdate() + timedelta(days=1)
+        self.special1.save()
+        response = self._get()
+        self.assertContains(response, "Active Special")
+        self.assertContains(response, self.special1.title)
+        self.assertContains(response, "Opens: 3")
+        self.assertContains(response, "CTA Clicks: 1")
+        self.assertContains(response, "Email Signups: 2")
 
 
 class IntegrationModelTests(TestCase):

--- a/templates/app/my_specials.html
+++ b/templates/app/my_specials.html
@@ -37,6 +37,12 @@
                   {% if active_special.end_date %}&nbsp;· Ends {{ active_special.end_date }}{% endif %}
                 </div>
 
+                <div class="small text-muted mb-3">
+                  Opens: {{ active_special.analytics.opens|default:0 }} ·
+                  CTA Clicks: {{ active_special.analytics.cta_clicks|default:0 }} ·
+                  Email Signups: {{ active_special.analytics.email_signups|default:0 }}
+                </div>
+
                 <!-- CTA buttons shown only if present -->
                 <div class="d-flex flex-wrap gap-2">
                   {% if active_special.order_url %}


### PR DESCRIPTION
## Summary
- display analytics for the active special owned by the logged-in user
- exercise active special stats with new regression test

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68a37a058dac83328c840f127c6d6461