### PR TITLE
Display Django messages as Bootstrap toasts

### DIFF
--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -34,6 +34,28 @@ class SignupEmailTests(TestCase):
         self.assertIn("verify", mail.outbox[0].body)
 
 
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+class MessageToastTests(TestCase):
+    """Verify Django messages render as Bootstrap toasts."""
+
+    def test_signup_displays_info_message_as_toast(self):
+        """Posting a valid signup shows a toast with the info message."""
+        response = self.client.post(
+            reverse("signup"),
+            {
+                "email": "toast@example.com",
+                "password1": "complexpass123",
+                "password2": "complexpass123",
+            },
+            follow=True,
+        )
+
+        # Final response should be the login page with a toast container
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "toast-container")
+        self.assertContains(response, "Check your email to verify your account.")
+
+
 class SocialLoginButtonTests(TestCase):
     def test_login_page_contains_social_buttons(self):
         response = self.client.get(reverse("login"))

--- a/specials/settings.py
+++ b/specials/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 from pathlib import Path
 import os
 from dotenv import load_dotenv
+from django.contrib.messages import constants as message_constants
 
 load_dotenv()
 
@@ -56,6 +57,15 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.google',
     'anymail',
 ]
+
+# Map Django message levels to Bootstrap alert classes
+MESSAGE_TAGS = {
+    message_constants.DEBUG: 'secondary',
+    message_constants.INFO: 'info',
+    message_constants.SUCCESS: 'success',
+    message_constants.WARNING: 'warning',
+    message_constants.ERROR: 'danger',
+}
 
 STRIPE_API_KEY = 'your_stripe_secret_key_here'
 

--- a/templates/app/base.html
+++ b/templates/app/base.html
@@ -75,6 +75,27 @@ This single canvas contains multiple Django-ready files. Copy each into your pro
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="{% static 'appertivo.js' %}"></script>
 
+    {% if messages %}
+    <div class="toast-container position-fixed top-0 end-0 p-3">
+      {% for message in messages %}
+      <div class="toast align-items-center text-bg-{{ message.tags }} border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="5000">
+        <div class="d-flex">
+          <div class="toast-body">{{ message }}</div>
+          <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+        toastElList.map(function (toastEl) {
+          return new bootstrap.Toast(toastEl).show();
+        });
+      });
+    </script>
+    {% endif %}
+
     {% block body_extra %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Render Django messages as Bootstrap toasts in the base template
- Map message levels to Bootstrap color classes in settings
- Test signup flow renders info message inside toast

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b611a2248332bfe8150482d66609