### PR TITLE
Style allauth templates for Google single sign-on

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -3,7 +3,7 @@ import json
 import re
 from unittest.mock import patch
 from django.template.loader import render_to_string
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, RequestFactory
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -12,6 +12,23 @@ from .forms import SpecialForm
 from .models import Special, EmailSignup, Integration
 from .integrations import google
 from profiles.models import UserProfile
+
+
+class AllauthTemplateTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _render(self, template):
+        request = self.factory.get("/")
+        return render_to_string(template, request=request)
+
+    def test_account_login_template(self):
+        html = self._render("account/login.html")
+        self.assertIn("Connecting to Google", html)
+
+    def test_account_signup_template(self):
+        html = self._render("account/signup.html")
+        self.assertIn("Connecting to Google", html)
 
 
 class SpecialFormTemplateTests(TestCase):

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,28 @@
+{% extends "app/base.html" %}
+{% load socialaccount %}
+
+{% block content %}
+<div class="container py-4 mt-4" style="min-height: 100vh;">
+  <div class="row justify-content-center">
+    <div class="col-lg-7">
+      <div class="card shadow-lg border-0 rounded-3 fs-2">
+        <div class="card-header gradient-text fs-2 fw-extrabold text-center">
+          Welcome Back
+        </div>
+        <div class="card-body text-center">
+          <p class="fs-4">Connecting to Google...</p>
+          <a href="{% provider_login_url 'google' %}" id="google-login" class="btn btn-orange mt-3 text-white">Continue with Google</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const link = document.getElementById('google-login');
+    if (link) {
+      window.location.href = link.href;
+    }
+  });
+</script>
+{% endblock %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,0 +1,28 @@
+{% extends "app/base.html" %}
+{% load socialaccount %}
+
+{% block content %}
+<div class="container py-4 mt-4" style="min-height: 100vh;">
+  <div class="row justify-content-center">
+    <div class="col-lg-7">
+      <div class="card shadow-lg border-0 rounded-3 fs-2">
+        <div class="card-header gradient-text fs-2 fw-extrabold text-center">
+          Create Your Free Account
+        </div>
+        <div class="card-body text-center">
+          <p class="fs-4">Connecting to Google...</p>
+          <a href="{% provider_login_url 'google' process='signup' %}" id="google-signup" class="btn btn-orange mt-3 text-white">Continue with Google</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const link = document.getElementById('google-signup');
+    if (link) {
+      window.location.href = link.href;
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add branded allauth account login/signup templates that auto-redirect to Google and show "Connecting to Google" messaging
- cover new templates with tests ensuring Google messaging is present

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement django-cloudinary-storage)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e40ccac08332afee3ef381d0b106