### PR TITLE
Fix special form toggle and CTA visibility

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -100,6 +100,16 @@ class SpecialFormTemplateTests(TestCase):
         self.assertIn('id="id_ai_enhance"', html)
         self.assertIsNotNone(re.search(r'id="id_ai_enhance"[^>]*checked', html))
 
+    def test_ai_enhance_label_present(self):
+        html = self.render()
+        self.assertIn('AI Enhance', html)
+
+    def test_cta_buttons_present(self):
+        html = self.render()
+        self.assertIn('data-cta="order"', html)
+        self.assertIn('data-cta="call"', html)
+        self.assertIn('data-cta="mobile_order"', html)
+
 
 class ConnectionPartialTests(TestCase):
     def render(self):

--- a/templates/app/partials/special_form.html
+++ b/templates/app/partials/special_form.html
@@ -105,7 +105,7 @@
 
       <div class="form-check form-switch my-3">
         {{ form.ai_enhance|add_class:"form-check-input" }}
-        <label class="form-check-label" for="{{ form.ai_enhance.id_for_label }}"></label>
+        <label class="form-check-label" for="{{ form.ai_enhance.id_for_label }}">AI Enhance</label>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- ensure AI Enhance toggle includes visible label
- add tests ensuring CTA options and AI label render in special form

## Testing
- `python manage.py test` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8ac1980833290d6cc3c40981633