### PR TITLE
Serve widget JS with absolute URLs

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -506,4 +506,31 @@ class GooglePublishTests(TestCase):
         mock_publish.assert_called_once_with(self.special)
 
 
+class WidgetIntegrationTests(TestCase):
+    """Tests for widget JavaScript and setup."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="wuser", password="pw")
+
+    def test_widget_js_returns_javascript(self):
+        url = reverse("widget_js", args=[self.user.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/javascript")
+        self.assertIn("const WIDGET_API_URL", response.content.decode())
+
+    def test_demo_widget_js_returns_javascript(self):
+        url = reverse("demo_widget_js")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/javascript")
+        self.assertIn("const WIDGET_API_URL", response.content.decode())
+
+    def test_widget_setup_uses_absolute_script_url(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("widget_setup"))
+        expected_src = f"http://testserver{reverse('widget_js', args=[self.user.id])}"
+        self.assertIn(expected_src, response.content.decode())
+
+
 

--- a/templates/app/widget_setup.html
+++ b/templates/app/widget_setup.html
@@ -43,7 +43,7 @@
                 <div class="bg-slate-50 border border-slate-200 rounded-lg p-4 mb-4">
                     <code class="text-sm font-mono text-slate-800" id="embed-code">
 &lt;div id="appertivo-widget"&gt;&lt;/div&gt;
-&lt;script src="{% url 'widget_js' user.id %}"&gt;&lt;/script&gt;
+&lt;script src="{{ widget_js_url }}"&gt;&lt;/script&gt;
                     </code>
                 </div>
                 


### PR DESCRIPTION
## Summary
- Return executable JavaScript from widget endpoints
- Provide full domain script URL on widget setup page
- Cover widget JavaScript and embed code with tests

## Testing
- `python manage.py test` *(fails: app.Special.image requires Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_68ab52825ab08332aeafd9a3ee45159d