### PR TITLE
Add footer with navigation and company info to home page

### DIFF
--- a/app/tests_footer.py
+++ b/app/tests_footer.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HomeFooterTests(TestCase):
+    """Tests for the footer content on the home page."""
+
+    def test_footer_contains_navigation_and_info(self):
+        response = self.client.get(reverse('home'))
+        self.assertContains(response, '<footer', html=False)
+        for href in ['href="/"', 'href="/register/"', 'href="/login/"',
+                     'href="/dashboard/"', 'href="/specials/"',
+                     'href="/specials/create/"', 'href="/connections/"']:
+            with self.subTest(href=href):
+                self.assertContains(response, href, html=False)
+        self.assertContains(response, 'Future Articles')
+        self.assertContains(response, 'Appertivo Inc.')
+        self.assertContains(response, '123 Food St')
+        for social in ['https://facebook.com', 'https://x.com', 'https://instagram.com']:
+            with self.subTest(social=social):
+                self.assertContains(response, social)

--- a/templates/app/home.html
+++ b/templates/app/home.html
@@ -285,6 +285,42 @@
             </div>
         </div>
     </section>
+
+    <!-- Footer -->
+    <footer class="bg-slate-800 text-slate-200 py-12">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-4 gap-8">
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Pages</h3>
+                <ul class="space-y-2">
+                    <li><a href="/" class="hover:underline">Home</a></li>
+                    <li><a href="/register/" class="hover:underline">Register</a></li>
+                    <li><a href="/login/" class="hover:underline">Login</a></li>
+                    <li><a href="/dashboard/" class="hover:underline">Dashboard</a></li>
+                    <li><a href="/specials/" class="hover:underline">Specials</a></li>
+                    <li><a href="/specials/create/" class="hover:underline">Create Special</a></li>
+                    <li><a href="/connections/" class="hover:underline">Connections</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Future Articles</h3>
+                <ul class="space-y-2">
+                    <li>Coming soon</li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Company</h3>
+                <p>Appertivo Inc.<br>123 Food St<br>Flavor Town, USA</p>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Follow Us</h3>
+                <div class="flex space-x-4">
+                    <a href="https://facebook.com/appertivo" class="hover:text-white" aria-label="Facebook">FB</a>
+                    <a href="https://x.com/appertivo" class="hover:text-white" aria-label="X">X</a>
+                    <a href="https://instagram.com/appertivo" class="hover:text-white" aria-label="Instagram">IG</a>
+                </div>
+            </div>
+        </div>
+    </footer>
 </div>
 
 <!-- Demo Widget Script -->


### PR DESCRIPTION
## Summary
- add footer section to home page with navigation links, company details, and social media
- add test ensuring footer renders expected links and information

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68ac8465ceec83328351f8f0b02bd2ee