### PR TITLE
Add pricing section to home page with tests

### DIFF
--- a/app/tests_pricing_section.py
+++ b/app/tests_pricing_section.py
@@ -1,0 +1,24 @@
+"""Tests for pricing section on the home page."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HomePricingSectionTests(TestCase):
+    """Verify that the home page shows pricing plans and features."""
+
+    def test_home_page_displays_pricing_plans(self):
+        response = self.client.get(reverse('home'))
+        for plan in ["Free", "Pro", "Enterprise"]:
+            with self.subTest(plan=plan):
+                self.assertContains(response, plan)
+        for feature in [
+            "Website widget",
+            "Email capture",
+            "Post to Google Business Profile",
+            "Delivery App Integration",
+            "POS Integrations",
+            "All features for multiple restaurants",
+        ]:
+            with self.subTest(feature=feature):
+                self.assertContains(response, feature)

--- a/templates/app/home.html
+++ b/templates/app/home.html
@@ -256,6 +256,41 @@
         </div>
     </section>
 
+    <!-- Pricing Section -->
+    <section class="py-24 bg-slate-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-4xl font-bold text-slate-900 mb-4">Pricing</h2>
+                <p class="text-xl text-slate-600">Choose the plan that's right for you.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <div class="card stripe-shadow p-8">
+                    <h3 class="text-2xl font-semibold text-slate-900 mb-4">Free</h3>
+                    <ul class="space-y-2 text-slate-600">
+                        <li>Website widget</li>
+                        <li>Email capture</li>
+                        <li>Post to Google Business Profile</li>
+                    </ul>
+                </div>
+                <div class="card stripe-shadow p-8 opacity-60">
+                    <h3 class="text-2xl font-semibold text-slate-900 mb-2">Pro</h3>
+                    <p class="text-sm text-slate-500 mb-4">Coming soon</p>
+                    <ul class="space-y-2 text-slate-600">
+                        <li>Delivery App Integration</li>
+                        <li>POS Integrations</li>
+                    </ul>
+                </div>
+                <div class="card stripe-shadow p-8 opacity-60">
+                    <h3 class="text-2xl font-semibold text-slate-900 mb-2">Enterprise</h3>
+                    <p class="text-sm text-slate-500 mb-4">Coming soon</p>
+                    <ul class="space-y-2 text-slate-600">
+                        <li>All features for multiple restaurants</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Company Logos -->
     <section class="py-16 bg-white border-t border-slate-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- add pricing section to landing page with Free, Pro, and Enterprise plans
- cover pricing content with test ensuring plans and features display

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68addde38a948332a115356d5bf105f4