### PR TITLE
Show special previews across platforms

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -39,6 +39,45 @@ body {
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12), 0 8px 24px rgba(0, 0, 0, 0.08);
 }
 
+/* Platform preview cards */
+.platform-preview {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--background);
+    overflow: hidden;
+}
+
+.platform-header {
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0.5rem;
+}
+
+.platform-widget .platform-header {
+    background: var(--primary);
+    color: var(--primary-foreground);
+}
+
+.platform-google .platform-header {
+    background: #4285F4;
+    color: #fff;
+}
+
+.platform-instagram .platform-header {
+    background: linear-gradient(45deg, #f09433, #e6683c, #dc2743, #cc2366, #bc1888);
+    color: #fff;
+}
+
+.platform-facebook .platform-header {
+    background: #1877F2;
+    color: #fff;
+}
+
+.platform-x .platform-header {
+    background: #000;
+    color: #fff;
+}
+
 .btn-primary {
     background: linear-gradient(135deg, hsl(230 67% 51%), hsl(234 89% 74%));
     color: white;

--- a/templates/app/home.html
+++ b/templates/app/home.html
@@ -30,58 +30,14 @@
                 </div>
             </div>
             
-            <!-- Dashboard Preview -->
-            <div class="mt-20 max-w-4xl mx-auto">
-                <div class="stripe-glass stripe-shadow-lg rounded-2xl p-8 border" aria-label="Appertivo dashboard preview">
-                    <div class="bg-white rounded-xl stripe-shadow p-6">
-                        <div class="flex items-center justify-between mb-6">
-                            <div class="flex items-center">
-                                <div class="w-10 h-10 bg-gradient-to-r from-blue-500 to-violet-500 rounded-lg flex items-center justify-center" aria-hidden="true">
-                                    <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4"></path>
-                                    </svg>
-                                </div>
-                                <div class="ml-3">
-                                    <h3 class="text-lg font-semibold text-slate-900">Today’s Special</h3>
-                                    <p class="text-sm text-slate-500">Active across Google, website & email</p>
-                                </div>
-                            </div>
-                            <div class="flex items-center bg-green-50 text-green-700 px-3 py-1 rounded-full text-sm font-medium">
-                                <div class="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
-                                Live
-                            </div>
-                        </div>
-                        
-                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                            <div class="lg:col-span-2">
-                                <h4 class="text-xl font-semibold text-slate-900 mb-2">Truffle Mushroom Risotto</h4>
-                                <p class="text-slate-600 mb-4">AI-optimized description: creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan.</p>
-                                <div class="flex items-center space-x-6 text-sm text-slate-500">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                                        </svg>
-                                        1,247 views (last 7 days)
-                                    </div>
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
-                                        </svg>
-                                        89% engagement
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="flex flex-col justify-between">
-                                <div class="text-right">
-                                    <div class="text-3xl font-bold text-slate-900">$24</div>
-                                    <div class="text-sm text-slate-500">Limited time</div>
-                                </div>
-                                <button class="mt-4 btn-primary" data-cta="dashboard-order">
-                                    Order now
-                                </button>
-                            </div>
-                        </div>
-                    </div>
+            <!-- Special Distribution Preview -->
+            <div class="mt-20">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
+                    {% include 'app/partials/widget.html' %}
+                    {% include 'app/partials/google.html' %}
+                    {% include 'app/partials/instagram.html' %}
+                    {% include 'app/partials/facebook.html' %}
+                    {% include 'app/partials/x.html' %}
                 </div>
             </div>
         </div>

--- a/templates/app/partials/facebook.html
+++ b/templates/app/partials/facebook.html
@@ -1,0 +1,8 @@
+<div class="platform-preview platform-facebook" data-platform="facebook">
+    <div class="platform-header">Facebook</div>
+    <div class="p-4 text-sm">
+        <h4 class="font-semibold mb-2">Truffle Mushroom Risotto</h4>
+        <p class="text-slate-600 mb-2">Creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan.</p>
+        <div class="text-right font-bold">$24</div>
+    </div>
+</div>

--- a/templates/app/partials/google.html
+++ b/templates/app/partials/google.html
@@ -1,0 +1,8 @@
+<div class="platform-preview platform-google" data-platform="google">
+    <div class="platform-header">Google Post</div>
+    <div class="p-4 text-sm">
+        <h4 class="font-semibold mb-2">Truffle Mushroom Risotto</h4>
+        <p class="text-slate-600 mb-2">Creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan.</p>
+        <div class="text-right font-bold">$24</div>
+    </div>
+</div>

--- a/templates/app/partials/instagram.html
+++ b/templates/app/partials/instagram.html
@@ -1,0 +1,8 @@
+<div class="platform-preview platform-instagram" data-platform="instagram">
+    <div class="platform-header">Instagram</div>
+    <div class="p-4 text-sm">
+        <div class="bg-slate-200 h-32 mb-3"></div>
+        <h4 class="font-semibold mb-1">Truffle Mushroom Risotto</h4>
+        <p class="text-slate-600 text-xs">Creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan.</p>
+    </div>
+</div>

--- a/templates/app/partials/widget.html
+++ b/templates/app/partials/widget.html
@@ -1,0 +1,8 @@
+<div class="platform-preview platform-widget" data-platform="widget">
+    <div class="platform-header">Widget</div>
+    <div class="p-4 text-sm">
+        <h4 class="font-semibold mb-2">Truffle Mushroom Risotto</h4>
+        <p class="text-slate-600 mb-2">Creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan.</p>
+        <div class="text-right font-bold">$24</div>
+    </div>
+</div>

--- a/templates/app/partials/x.html
+++ b/templates/app/partials/x.html
@@ -1,0 +1,6 @@
+<div class="platform-preview platform-x" data-platform="x">
+    <div class="platform-header">X</div>
+    <div class="p-4 text-sm">
+        <p><strong>Truffle Mushroom Risotto</strong> – Creamy arborio rice with wild mushrooms, finished with truffle oil and aged parmesan. $24</p>
+    </div>
+</div>

--- a/tests/tests_special_previews.py
+++ b/tests/tests_special_previews.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.urls import reverse
+
+class SpecialPreviewTests(TestCase):
+    """Tests for special distribution previews on home page."""
+
+    def test_home_page_shows_platform_previews(self):
+        response = self.client.get(reverse('home'))
+        self.assertContains(response, 'data-platform="widget"')
+        self.assertContains(response, 'data-platform="google"')
+        self.assertContains(response, 'data-platform="instagram"')
+        self.assertContains(response, 'data-platform="facebook"')
+        self.assertContains(response, 'data-platform="x"')


### PR DESCRIPTION
## Summary
- Replace dashboard demo with row of platform previews for Truffle Mushroom Risotto
- Add partial templates and styling for widget, Google, Instagram, Facebook, and X
- Test home page renders all platform previews

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'stripe')*


------
https://chatgpt.com/codex/tasks/task_e_68b0a44bcf988332aa7963cb011bb5aa