### PR TITLE
Show active specials on dashboard

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -134,8 +134,7 @@ def dashboard(request):
             show_location_modal = True
             locations = settings_data.get("locations", [])
 
-    specials = Special.objects.filter(user=request.user)
-    active_specials = specials.filter(status='active')
+    active_specials = Special.objects.filter(user=request.user, status='active')
 
     total_email_signups = EmailSignup.objects.filter(restaurant=request.user).count()
     total_email_signups_from_specials = sum(special.email_signups for special in active_specials)
@@ -148,7 +147,7 @@ def dashboard(request):
     }
 
     context = {
-        'specials': specials[:3],  # Latest 3 for overview
+        'specials': active_specials[:3],  # Latest 3 active specials
         'stats': stats,
         'show_location_modal': show_location_modal,
         'google_locations': locations,

--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -79,12 +79,6 @@
                     </svg>
                     Create Special
                 </a>
-                <a href="{% url 'specials_list' %}" class="btn-outline text-center" data-testid="button-view-specials">
-                    <svg class="w-5 h-5 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                    </svg>
-                    View All Specials
-                </a>
                 <a href="{% url 'connections' %}" class="btn-outline text-center" data-testid="button-manage-connections">
                     <svg class="w-5 h-5 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
@@ -100,62 +94,20 @@
             </div>
         </div>
 
-        <!-- Recent Specials -->
+        <!-- Active Specials -->
         <div class="bg-white stripe-shadow rounded-lg">
-            <div class="px-6 py-4 border-b border-slate-200">
-                <div class="flex items-center justify-between">
-                    <h2 class="text-lg font-semibold text-slate-900">Recent Specials</h2>
-                    <a href="{% url 'specials_list' %}" class="text-blue-600 hover:text-blue-700 font-medium text-sm">View all</a>
-                </div>
+            <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
+                <h2 class="text-lg font-semibold text-slate-900">Active Specials</h2>
+                <a href="{% url 'specials_list' %}" class="btn-outline text-sm" data-testid="button-view-all-specials">View All Specials</a>
             </div>
-            
+
             {% if specials %}
-                <div class="divide-y divide-slate-200">
-                    {% for special in specials %}
-                        <div class="p-6" data-testid="card-special-{{ special.id }}">
-                            <div class="flex items-center justify-between">
-                                <div class="flex-1">
-                                    <div class="flex items-center">
-                                        <h3 class="text-lg font-medium text-slate-900" data-testid="text-special-title">{{ special.title }}</h3>
-                                        <span class="ml-3 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                                            {% if special.status == 'active' %}bg-green-100 text-green-800{% elif special.status == 'draft' %}bg-yellow-100 text-yellow-800{% else %}bg-slate-100 text-slate-800{% endif %}">
-                                            {{ special.get_status_display }}
-                                        </span>
-                                    </div>
-                                    <p class="mt-1 text-slate-600">{{ special.description|truncatewords:20 }}</p>
-                                    <div class="mt-2 flex items-center space-x-4 text-sm text-slate-500">
-                                        <span class="flex items-center">
-                                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
-                                            </svg>
-                                            ${{ special.price }}
-                                        </span>
-                                        <span class="flex items-center">
-                                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
-                                            </svg>
-                                            {{ special.views }} views
-                                        </span>
-                                        <span class="flex items-center">
-                                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"></path>
-                                            </svg>
-                                            {{ special.clicks }} clicks
-                                        </span>
-                                    </div>
-                                </div>
-                                <div class="ml-4 flex-shrink-0 flex space-x-2">
-                                    <button class="btn-outline text-sm py-2 px-3">Edit</button>
-                                    <button class="text-slate-400 hover:text-slate-600">
-                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"></path>
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    {% endfor %}
+                <div class="p-6">
+                    <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+                        {% for special in specials %}
+                            {% include 'app/partials/special_card.html' %}
+                        {% endfor %}
+                    </div>
                 </div>
             {% else %}
                 <div class="p-12 text-center">

--- a/templates/app/list.html
+++ b/templates/app/list.html
@@ -25,78 +25,7 @@
         {% if specials %}
             <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
                 {% for special in specials %}
-                    <div class="card stripe-shadow hover:stripe-shadow-lg transition-all duration-200" data-testid="card-special-{{ special.id }}">
-                        {% if special.image %}
-                            <img src="{{ special.image.url }}" alt="{{ special.title }}" class="h-48 w-full object-cover rounded-t-lg">
-                        {% endif %}
-                        <div class="p-6">
-                            <div class="flex items-center justify-between mb-4">
-                                <h3 class="text-lg font-semibold text-slate-900" data-testid="text-special-title">{{ special.title }}</h3>
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                                    {% if special.status == 'active' %}bg-green-100 text-green-800{% elif special.status == 'draft' %}bg-yellow-100 text-yellow-800{% else %}bg-slate-100 text-slate-800{% endif %}">
-                                    {{ special.get_status_display }}
-                                </span>
-                            </div>
-                            
-                            <p class="text-slate-600 mb-4" data-testid="text-special-description">{{ special.description|truncatewords:20 }}</p>
-                            
-                            <div class="flex items-center justify-between mb-4">
-                                <div class="text-2xl font-bold text-slate-900" data-testid="text-special-price">${{ special.price }}</div>
-                                <div class="text-sm text-slate-500">
-                                    Ends {{ special.end_date|date:"M d, Y" }}
-                                </div>
-                            </div>
-                            
-                            <div class="grid grid-cols-3 gap-4 text-center text-sm text-slate-500 mb-4">
-                                <div>
-                                    <div class="font-medium text-slate-900" data-testid="stat-views">{{ special.views }}</div>
-                                    <div>Views</div>
-                                </div>
-                                <div>
-                                    <div class="font-medium text-slate-900" data-testid="stat-clicks">{{ special.clicks }}</div>
-                                    <div>Clicks</div>
-                                </div>
-                                <div>
-                                    <div class="font-medium text-slate-900" data-testid="stat-shares">{{ special.shares }}</div>
-                                    <div>Shares</div>
-                                </div>
-                            </div>
-                            
-                            <div class="flex space-x-2">
-                                <button class="flex-1 btn-outline text-sm py-2" data-testid="button-edit-special"
-                                    data-id="{{ special.id }}"
-                                    data-title="{{ special.title }}"
-                                    data-description="{{ special.description }}"
-                                    data-price="{{ special.price }}"
-                                    data-start-date="{{ special.start_date|date:'Y-m-d\TH:i' }}"
-                                    data-end-date="{{ special.end_date|date:'Y-m-d\TH:i' }}"
-                                    data-cta-type="{{ special.cta_type }}"
-                                    data-cta-url="{{ special.cta_url }}"
-                                    data-cta-phone="{{ special.cta_phone }}">
-                                    Edit
-                                </button>
-                                {% if special.status == 'active' %}
-                                <form method="post" action="{% url 'special_unpublish' special.id %}" class="flex-1">
-                                    {% csrf_token %}
-                                    <button class="w-full btn-primary text-sm py-2" data-testid="button-unpublish-special">Sold Out</button>
-                                </form>
-                                {% else %}
-                                <form method="post" action="{% url 'special_publish' special.id %}" class="flex-1">
-                                    {% csrf_token %}
-                                    <button class="w-full btn-primary text-sm py-2" data-testid="button-publish-special">Publish</button>
-                                </form>
-                                {% endif %}
-                                <form method="post" action="{% url 'special_delete' special.id %}">
-                                    {% csrf_token %}
-                                    <button class="px-3 py-2 text-slate-400 hover:text-slate-600" data-testid="button-delete-special">
-                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 7h12M9 7v10m6-10v10M4 7h16l-1 12a2 2 0 01-2 2H7a2 2 0 01-2-2L4 7zm3-3h10a1 1 0 011 1v2H6V5a1 1 0 011-1z" />
-                                        </svg>
-                                    </button>
-                                </form>
-                            </div>
-                        </div>
-                    </div>
+                    {% include 'app/partials/special_card.html' %}
                 {% endfor %}
             </div>
         {% else %}

--- a/templates/app/partials/special_card.html
+++ b/templates/app/partials/special_card.html
@@ -1,0 +1,72 @@
+<div class="card stripe-shadow hover:stripe-shadow-lg transition-all duration-200" data-testid="card-special-{{ special.id }}">
+    {% if special.image %}
+        <img src="{{ special.image.url }}" alt="{{ special.title }}" class="h-48 w-full object-cover rounded-t-lg">
+    {% endif %}
+    <div class="p-6">
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-slate-900" data-testid="text-special-title">{{ special.title }}</h3>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                {% if special.status == 'active' %}bg-green-100 text-green-800{% elif special.status == 'draft' %}bg-yellow-100 text-yellow-800{% else %}bg-slate-100 text-slate-800{% endif %}>
+                {{ special.get_status_display }}
+            </span>
+        </div>
+
+        <p class="text-slate-600 mb-4" data-testid="text-special-description">{{ special.description|truncatewords:20 }}</p>
+
+        <div class="flex items-center justify-between mb-4">
+            <div class="text-2xl font-bold text-slate-900" data-testid="text-special-price">${{ special.price }}</div>
+            <div class="text-sm text-slate-500">
+                Ends {{ special.end_date|date:"M d, Y" }}
+            </div>
+        </div>
+
+        <div class="grid grid-cols-3 gap-4 text-center text-sm text-slate-500 mb-4">
+            <div>
+                <div class="font-medium text-slate-900" data-testid="stat-views">{{ special.views }}</div>
+                <div>Views</div>
+            </div>
+            <div>
+                <div class="font-medium text-slate-900" data-testid="stat-clicks">{{ special.clicks }}</div>
+                <div>Clicks</div>
+            </div>
+            <div>
+                <div class="font-medium text-slate-900" data-testid="stat-shares">{{ special.shares }}</div>
+                <div>Shares</div>
+            </div>
+        </div>
+
+        <div class="flex space-x-2">
+            <button class="flex-1 btn-outline text-sm py-2" data-testid="button-edit-special"
+                data-id="{{ special.id }}"
+                data-title="{{ special.title }}"
+                data-description="{{ special.description }}"
+                data-price="{{ special.price }}"
+                data-start-date="{{ special.start_date|date:'Y-m-d\\TH:i' }}"
+                data-end-date="{{ special.end_date|date:'Y-m-d\\TH:i' }}"
+                data-cta-type="{{ special.cta_type }}"
+                data-cta-url="{{ special.cta_url }}"
+                data-cta-phone="{{ special.cta_phone }}">
+                Edit
+            </button>
+            {% if special.status == 'active' %}
+            <form method="post" action="{% url 'special_unpublish' special.id %}" class="flex-1">
+                {% csrf_token %}
+                <button class="w-full btn-primary text-sm py-2" data-testid="button-unpublish-special">Sold Out</button>
+            </form>
+            {% else %}
+            <form method="post" action="{% url 'special_publish' special.id %}" class="flex-1">
+                {% csrf_token %}
+                <button class="w-full btn-primary text-sm py-2" data-testid="button-publish-special">Publish</button>
+            </form>
+            {% endif %}
+            <form method="post" action="{% url 'special_delete' special.id %}">
+                {% csrf_token %}
+                <button class="px-3 py-2 text-slate-400 hover:text-slate-600" data-testid="button-delete-special">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 7h12M9 7v10m6-10v10M4 7h16l-1 12a2 2 0 01-2 2H7a2 2 0 01-2-2L4 7zm3-3h10a1 1 0 011 1v2H6V5a1 1 0 011-1z" />
+                    </svg>
+                </button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/tests/tests_dashboard_specials.py
+++ b/tests/tests_dashboard_specials.py
@@ -1,0 +1,70 @@
+from datetime import timedelta
+import re
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.template.loader import render_to_string
+from django.contrib.auth.models import User
+
+from app.models import Special
+
+
+class DashboardSpecialsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pw")
+        self.client.login(username="owner", password="pw")
+
+    def _create_special(self, **kwargs):
+        defaults = dict(
+            user=self.user,
+            title="Deal",
+            description="Desc",
+            price="10.00",
+            start_date=timezone.now() - timedelta(days=1),
+            end_date=timezone.now() + timedelta(days=1),
+            status="active",
+            cta_type="web",
+            cta_url="",
+            cta_phone="",
+        )
+        defaults.update(kwargs)
+        return Special.objects.create(**defaults)
+
+    def test_dashboard_shows_only_active_specials_and_view_all_button(self):
+        active = self._create_special(title="Active")
+        self._create_special(status="expired", title="Expired")
+
+        response = self.client.get(reverse("dashboard"))
+        self.assertContains(response, active.title)
+        self.assertNotContains(response, "Expired")
+        self.assertContains(response, reverse("specials_list"))
+        self.assertContains(response, "data-testid=\"button-view-all-specials\"")
+        self.assertNotContains(response, "data-testid=\"button-view-specials\"")
+
+    def test_dashboard_special_card_matches_list(self):
+        special = self._create_special(title="Match")
+
+        dashboard = self.client.get(reverse("dashboard"))
+        specials_list = self.client.get(reverse("specials_list"))
+
+        expected = render_to_string(
+            "app/partials/special_card.html",
+            {"special": special},
+            request=dashboard.wsgi_request,
+        )
+        # remove csrf tokens and collapse whitespace
+        expected = re.sub(r"<input[^>]*csrfmiddlewaretoken[^>]*>", "", expected)
+        expected = re.sub(r"\s+", " ", expected.strip())
+
+        dash_html = re.sub(
+            r"<input[^>]*csrfmiddlewaretoken[^>]*>", "", dashboard.content.decode()
+        )
+        dash_html = re.sub(r"\s+", " ", dash_html)
+
+        list_html = re.sub(
+            r"<input[^>]*csrfmiddlewaretoken[^>]*>", "", specials_list.content.decode()
+        )
+        list_html = re.sub(r"\s+", " ", list_html)
+
+        self.assertIn(expected, dash_html)
+        self.assertIn(expected, list_html)


### PR DESCRIPTION
## Summary
- Only show active specials on dashboard using the same card layout as the specials list
- Add "View All Specials" button and remove quick-action shortcut
- Share card template between dashboard and specials list

## Testing
- `python manage.py test` *(fails: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68b0d9f80a508332ac48f0c243e410ca