### PR TITLE
Add calendar view for specials

### DIFF
--- a/app/migrations/0008_userprofile_default_view.py
+++ b/app/migrations/0008_userprofile_default_view.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0007_userprofile_stripe_customer_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="default_view",
+            field=models.CharField(
+                choices=[("list", "List"), ("calendar", "Calendar")],
+                default="list",
+                max_length=10,
+            ),
+        ),
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -108,6 +108,11 @@ class UserProfile(models.Model):
         choices=[('free', 'Free'), ('pro', 'Pro'), ('enterprise', 'Enterprise')],
         default='free'
     )
+    default_view = models.CharField(
+        max_length=10,
+        choices=[('list', 'List'), ('calendar', 'Calendar')],
+        default='list',
+    )
 
     def __str__(self):
         return f"{self.user.username} - {self.restaurant_name}"

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,22 @@
+import calendar
+from collections import defaultdict
+
+
+def month_cells(year, month, specials):
+    """Return calendar weeks for the given month with specials attached."""
+    cal = calendar.Calendar()
+    weeks = cal.monthdatescalendar(year, month)
+    specials_by_day = defaultdict(list)
+    for special in specials:
+        specials_by_day[special.start_date.date()].append(special)
+    result = []
+    for week in weeks:
+        result.append([
+            {
+                "date": day,
+                "specials": specials_by_day.get(day, []),
+                "in_month": day.month == month,
+            }
+            for day in week
+        ])
+    return result

--- a/app/views.py
+++ b/app/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.contrib import messages
 from django.http import JsonResponse, HttpResponse, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import require_http_methods, require_POST
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover
 load_dotenv()
 
 from django.utils import timezone
+from datetime import date
 from .models import (
     Special,
     Restaurant,
@@ -42,13 +43,7 @@ from .models import (
 )
 from .forms import SpecialForm
 from app.integrations.google import *
-from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
-from django.shortcuts import redirect, render
-from django.urls import reverse
-from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods, require_POST
+from .utils import month_cells
 
 logger = logging.getLogger(__name__)
 
@@ -400,9 +395,40 @@ def cancel_subscription(request):
 
 @login_required
 def specials_list(request):
-    """List all specials"""
+    """List specials in list or calendar view."""
+    profile = getattr(request.user, "profile", None)
+    view = request.GET.get("view")
+    if profile:
+        if view in {"list", "calendar"}:
+            if profile.default_view != view:
+                profile.default_view = view
+                profile.save(update_fields=["default_view"])
+        else:
+            view = profile.default_view
+    else:
+        view = "list"
+
     specials = Special.objects.filter(user=request.user)
-    return render(request, 'app/list.html', {'specials': specials})
+    if view == "calendar":
+        today = timezone.localdate()
+        year = int(request.GET.get("year", today.year))
+        month = int(request.GET.get("month", today.month))
+        cells = month_cells(year, month, specials)
+        current_month = date(year, month, 1)
+        prev_month = date(year - 1, 12, 1) if month == 1 else date(year, month - 1, 1)
+        next_month = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+        context = {
+            "cells": cells,
+            "current_month": current_month,
+            "prev_month": prev_month,
+            "next_month": next_month,
+            "current_view": "calendar",
+        }
+        template = "app/calendar.html"
+    else:
+        context = {"specials": specials, "current_view": "list"}
+        template = "app/list.html"
+    return render(request, template, context)
 
 
 @login_required

--- a/templates/app/calendar.html
+++ b/templates/app/calendar.html
@@ -1,0 +1,35 @@
+{% extends 'base/base.html' %}
+{% block title %}Specials Calendar - Appertivo{% endblock %}
+{% block content %}
+<div class="min-h-screen bg-slate-50">
+    {% include 'base/dashboard_nav.html' %}
+    <main class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+        <div class="mb-8 flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-bold text-slate-900">Specials Calendar</h1>
+            </div>
+            {% include 'app/partials/view_toggle.html' %}
+        </div>
+        <div class="flex items-center justify-between mb-4">
+            <a href="?view=calendar&year={{ prev_month.year }}&month={{ prev_month.month }}" class="btn-outline">&lt;</a>
+            <h2 class="text-xl font-semibold">{{ current_month|date:"F Y" }}</h2>
+            <a href="?view=calendar&year={{ next_month.year }}&month={{ next_month.month }}" class="btn-outline">&gt;</a>
+        </div>
+        <div class="grid grid-cols-7 gap-2">
+            {% for week in cells %}
+                {% for day in week %}
+                    <div class="border rounded p-2 {% if not day.in_month %}opacity-50{% endif %}">
+                        <div class="text-sm font-semibold">{{ day.date.day }}</div>
+                        {% for special in day.specials %}
+                            <div class="mt-1 text-xs truncate">{{ special.title }}</div>
+                        {% endfor %}
+                        {% if not day.specials %}
+                            <div class="mt-1 text-xs text-slate-400">+ Add</div>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            {% endfor %}
+        </div>
+    </main>
+</div>
+{% endblock %}

--- a/templates/app/list.html
+++ b/templates/app/list.html
@@ -14,12 +14,15 @@
                 <h1 class="text-2xl font-bold text-slate-900">All Specials</h1>
                 <p class="mt-2 text-slate-600">Manage your restaurant's daily specials and promotions.</p>
             </div>
-            <a href="{% url 'create_special' %}" class="btn-primary" data-testid="button-create-special">
-                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
-                </svg>
-                Create Special
-            </a>
+            <div class="flex items-center space-x-2">
+                {% include 'app/partials/view_toggle.html' %}
+                <a href="{% url 'create_special' %}" class="btn-primary" data-testid="button-create-special">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                    </svg>
+                    Create Special
+                </a>
+            </div>
         </div>
 
         {% if specials %}

--- a/templates/app/partials/view_toggle.html
+++ b/templates/app/partials/view_toggle.html
@@ -1,0 +1,4 @@
+<div class="flex space-x-2">
+    <a href="?view=list" class="{% if current_view == 'list' %}btn-primary{% else %}btn-outline{% endif %}">List</a>
+    <a href="?view=calendar" class="{% if current_view == 'calendar' %}btn-primary{% else %}btn-outline{% endif %}">Calendar</a>
+</div>

--- a/tests/tests_calendar_view.py
+++ b/tests/tests_calendar_view.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from app.models import Special, UserProfile
+from app.utils import month_cells
+
+
+class MonthCellsTests(TestCase):
+    def test_month_cells_includes_specials(self):
+        user = User.objects.create_user(username="owner", password="pw")
+        UserProfile.objects.create(user=user, restaurant_name="R")
+        start = timezone.make_aware(datetime(2024, 5, 10, 12, 0))
+        end = start + timedelta(hours=2)
+        special = Special.objects.create(
+            user=user,
+            title="Taco",
+            description="desc",
+            price=5,
+            start_date=start,
+            end_date=end,
+            status="active",
+            cta_type="web",
+            cta_url="",
+        )
+        weeks = month_cells(2024, 5, Special.objects.filter(user=user))
+        self.assertTrue(all(len(week) == 7 for week in weeks))
+        self.assertTrue(
+            any(
+                cell["date"] == start.date() and special in cell["specials"]
+                for week in weeks
+                for cell in week
+            )
+        )
+
+
+class SpecialsListToggleTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pw")
+        self.profile = UserProfile.objects.create(user=self.user, restaurant_name="R")
+        self.client.login(username="owner", password="pw")
+
+    def test_toggle_updates_default_view(self):
+        response = self.client.get(reverse("specials_list") + "?view=calendar")
+        self.assertTemplateUsed(response, "app/calendar.html")
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.default_view, "calendar")


### PR DESCRIPTION
## Summary
- add per-user default view for specials
- introduce calendar view with month grid and toggle
- cover calendar helper and view preference with tests

## Testing
- `python manage.py test` *(fails: Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b71c7f4bb08332bbd159571f145a6d