### PR TITLE
Use FullCalendar for specials calendar

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -30,7 +30,6 @@ except ImportError:  # pragma: no cover
 load_dotenv()
 
 from django.utils import timezone
-from datetime import date
 from .models import (
     Special,
     Restaurant,
@@ -43,7 +42,6 @@ from .models import (
 )
 from .forms import SpecialForm
 from app.integrations.google import *
-from .utils import month_cells
 
 logger = logging.getLogger(__name__)
 
@@ -410,18 +408,22 @@ def specials_list(request):
 
     specials = Special.objects.filter(user=request.user)
     if view == "calendar":
-        today = timezone.localdate()
-        year = int(request.GET.get("year", today.year))
-        month = int(request.GET.get("month", today.month))
-        cells = month_cells(year, month, specials)
-        current_month = date(year, month, 1)
-        prev_month = date(year - 1, 12, 1) if month == 1 else date(year, month - 1, 1)
-        next_month = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+        events = []
+        for s in specials:
+            color = "#22c55e" if s.status == "active" else "#6b7280"
+            events.append(
+                {
+                    "id": str(s.id),
+                    "title": s.title,
+                    "start": s.start_date.isoformat(),
+                    "end": s.end_date.isoformat(),
+                    "color": color,
+                    "edit_url": reverse("special_edit", args=[s.id]),
+                }
+            )
         context = {
-            "cells": cells,
-            "current_month": current_month,
-            "prev_month": prev_month,
-            "next_month": next_month,
+            "events": events,
+            "create_url": reverse("create_special"),
             "current_view": "calendar",
         }
         template = "app/calendar.html"

--- a/templates/app/calendar.html
+++ b/templates/app/calendar.html
@@ -10,26 +10,60 @@
             </div>
             {% include 'app/partials/view_toggle.html' %}
         </div>
-        <div class="flex items-center justify-between mb-4">
-            <a href="?view=calendar&year={{ prev_month.year }}&month={{ prev_month.month }}" class="btn-outline">&lt;</a>
-            <h2 class="text-xl font-semibold">{{ current_month|date:"F Y" }}</h2>
-            <a href="?view=calendar&year={{ next_month.year }}&month={{ next_month.month }}" class="btn-outline">&gt;</a>
-        </div>
-        <div class="grid grid-cols-7 gap-2">
-            {% for week in cells %}
-                {% for day in week %}
-                    <div class="border rounded p-2 {% if not day.in_month %}opacity-50{% endif %}">
-                        <div class="text-sm font-semibold">{{ day.date.day }}</div>
-                        {% for special in day.specials %}
-                            <div class="mt-1 text-xs truncate">{{ special.title }}</div>
-                        {% endfor %}
-                        {% if not day.specials %}
-                            <div class="mt-1 text-xs text-slate-400">+ Add</div>
-                        {% endif %}
-                    </div>
-                {% endfor %}
-            {% endfor %}
-        </div>
+        <div id="calendar"></div>
     </main>
 </div>
+
+<div id="modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white p-4 rounded shadow max-w-sm w-full">
+        <div id="modal-body" class="mb-4"></div>
+        <button id="modal-close" class="btn-primary w-full">Close</button>
+    </div>
+</div>
+
+{{ events|json_script:"events-data" }}
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const events = JSON.parse(document.getElementById('events-data').textContent);
+    const calendarEl = document.getElementById('calendar');
+    const createUrl = "{{ create_url }}";
+
+    function openModal(html) {
+        const modal = document.getElementById('modal');
+        const body = document.getElementById('modal-body');
+        body.innerHTML = html;
+        modal.classList.remove('hidden');
+    }
+    document.getElementById('modal-close').addEventListener('click', function() {
+        document.getElementById('modal').classList.add('hidden');
+    });
+
+    const calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        events: events,
+        dateClick: function(info) {
+            const url = createUrl + '?date=' + info.dateStr;
+            openModal('<a href="' + url + '" class="btn-primary">Add Special</a>');
+        },
+        eventClick: function(info) {
+            const url = info.event.extendedProps.edit_url;
+            openModal('<a href="' + url + '" class="btn-primary">Edit Special</a>');
+        },
+        dayCellDidMount: function(arg) {
+            const btn = document.createElement('button');
+            btn.textContent = '+';
+            btn.className = 'absolute top-1 right-1 text-xs text-blue-500';
+            btn.addEventListener('click', function(e) {
+                e.stopPropagation();
+                const url = createUrl + '?date=' + arg.date.toISOString().slice(0,10);
+                openModal('<a href="' + url + '" class="btn-primary">Add Special</a>');
+            });
+            arg.el.style.position = 'relative';
+            arg.el.appendChild(btn);
+        }
+    });
+    calendar.render();
+});
+</script>
 {% endblock %}

--- a/tests/tests_calendar_view.py
+++ b/tests/tests_calendar_view.py
@@ -47,3 +47,41 @@ class SpecialsListToggleTests(TestCase):
         self.assertTemplateUsed(response, "app/calendar.html")
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.default_view, "calendar")
+
+
+class CalendarEventsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pw")
+        UserProfile.objects.create(user=self.user, restaurant_name="R")
+        self.client.login(username="owner", password="pw")
+
+    def test_calendar_view_includes_status_colors(self):
+        start = timezone.now()
+        end = start + timedelta(hours=1)
+        active = Special.objects.create(
+            user=self.user,
+            title="Active",
+            description="desc",
+            price=5,
+            start_date=start,
+            end_date=end,
+            status="active",
+            cta_type="web",
+            cta_url="",
+        )
+        expired = Special.objects.create(
+            user=self.user,
+            title="Expired",
+            description="desc",
+            price=5,
+            start_date=start - timedelta(days=1),
+            end_date=end - timedelta(days=1),
+            status="expired",
+            cta_type="web",
+            cta_url="",
+        )
+        response = self.client.get(reverse("specials_list") + "?view=calendar")
+        events = response.context["events"]
+        colors = {e["id"]: e["color"] for e in events}
+        self.assertEqual(colors[str(active.id)], "#22c55e")
+        self.assertEqual(colors[str(expired.id)], "#6b7280")


### PR DESCRIPTION
## Summary
- replace static calendar grid with FullCalendar component and modal interactions
- expose specials as JSON events with status-based colors
- add tests covering event color data for calendar view

## Testing
- `python manage.py test` *(fails: ImportError: Failed to import test module: app.tests_billing)*
- `python manage.py test tests.tests_calendar_view`

------
https://chatgpt.com/codex/tasks/task_e_68b72332c6788332b7493f607e53434e