### PR TITLE
Fix special form update action

### DIFF
--- a/templates/app/partials/special_form.html
+++ b/templates/app/partials/special_form.html
@@ -1,4 +1,6 @@
-<form method="post" enctype="multipart/form-data" class="p-6 space-y-6">
+<form method="post"
+      action="{% if special %}{% url 'special_edit' special.id %}{% else %}{% url 'create_special' %}{% endif %}"
+      enctype="multipart/form-data" class="p-6 space-y-6">
     {% csrf_token %}
 
     <!-- Image Upload -->

--- a/tests/tests_special_form_partial.py
+++ b/tests/tests_special_form_partial.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from app.models import Special
+
+
+class SpecialFormPartialTests(TestCase):
+    """Tests for the special form partial template."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pw")
+        self.client.login(username="owner", password="pw")
+
+    def _create_special(self):
+        return Special.objects.create(
+            user=self.user,
+            title="Deal",
+            description="Desc",
+            price="10.00",
+            start_date=timezone.now() - timedelta(days=1),
+            end_date=timezone.now() + timedelta(days=1),
+            cta_type="web",
+            cta_url="",
+            cta_phone="",
+            status="active",
+        )
+
+    def test_create_partial_has_action(self):
+        url = reverse("special_form_create_partial")
+        response = self.client.get(url)
+        self.assertContains(response, f'action="{reverse("create_special")}"')
+
+    def test_edit_partial_has_action(self):
+        special = self._create_special()
+        url = reverse("special_form_edit_partial", args=[special.id])
+        response = self.client.get(url)
+        self.assertContains(response, f'action="{reverse("special_edit", args=[special.id])}"')


### PR DESCRIPTION
## Summary
- ensure special form submits to create or edit endpoint
- test partial form actions

## Testing
- `python manage.py test tests` *(fails: ModuleNotFoundError, cancellations, and unrelated failing tests)*
- `python manage.py test tests.tests_special_form_partial`


------
https://chatgpt.com/codex/tasks/task_e_68b74edb8c0c83328f0719566d8318b1