### PR TITLE
Add mobile hamburger menu for dashboard navigation

### DIFF
--- a/templates/base/dashboard_nav.html
+++ b/templates/base/dashboard_nav.html
@@ -11,7 +11,7 @@
                         </div>
                         <span class="ml-3 text-xl font-semibold text-slate-900">Appertivo</span>
                     </div>
-                    
+
                     <div class="hidden md:flex ml-10 space-x-8">
                         <a href="{% url 'dashboard' %}" class="text-slate-600 hover:text-slate-900 font-medium py-4">Dashboard</a>
                         <a href="{% url 'specials_list' %}" class="text-slate-600 hover:text-slate-900 font-medium py-4">Specials</a>
@@ -20,13 +20,43 @@
                         <a href="{% url 'billing' %}" class="text-slate-600 hover:text-slate-900 font-medium py-4">Billing</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
+
+                <div class="hidden md:flex items-center space-x-4">
                     <div class="text-sm text-slate-600">
                         Welcome, {{ user.profile.restaurant_name|default:user.username }}
                     </div>
                     <a href="{% url 'logout' %}" class="text-slate-600 hover:text-slate-900 font-medium">Sign out</a>
                 </div>
+
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-slate-600 focus:outline-none">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div id="mobile-menu" class="hidden md:hidden border-t border-slate-200">
+            <div class="px-4 pt-4 pb-6 space-y-4">
+                <a href="{% url 'dashboard' %}" class="block text-slate-600 hover:text-slate-900">Dashboard</a>
+                <a href="{% url 'specials_list' %}" class="block text-slate-600 hover:text-slate-900">Specials</a>
+                <a href="{% url 'widget_setup' %}" class="block text-slate-600 hover:text-slate-900">Widget</a>
+                <a href="{% url 'connections' %}" class="block text-slate-600 hover:text-slate-900">Connections</a>
+                <a href="{% url 'billing' %}" class="block text-slate-600 hover:text-slate-900">Billing</a>
+                <a href="{% url 'logout' %}" class="block text-slate-600 hover:text-slate-900">Sign out</a>
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const button = document.getElementById('mobile-menu-button');
+            const menu = document.getElementById('mobile-menu');
+            if (button) {
+                button.addEventListener('click', function () {
+                    menu.classList.toggle('hidden');
+                });
+            }
+        });
+    </script>
+

--- a/tests/tests_dashboard_mobile_nav.py
+++ b/tests/tests_dashboard_mobile_nav.py
@@ -1,0 +1,26 @@
+"""Tests for mobile navigation in the dashboard."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+
+class DashboardMobileNavigationTests(TestCase):
+    """Ensure the dashboard mobile menu appears with expected links."""
+
+    def setUp(self):
+        User = get_user_model()
+        User.objects.create_user(username="tester", password="pass123")
+
+    def test_mobile_menu_contains_links_for_authenticated_user(self):
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(reverse('dashboard'))
+        self.assertContains(response, 'id="mobile-menu-button"', html=False)
+        self.assertContains(response, 'id="mobile-menu"', html=False)
+        self.assertContains(response, reverse('dashboard'))
+        self.assertContains(response, reverse('specials_list'))
+        self.assertContains(response, reverse('widget_setup'))
+        self.assertContains(response, reverse('connections'))
+        self.assertContains(response, reverse('billing'))
+        self.assertContains(response, reverse('logout'))
+


### PR DESCRIPTION
## Summary
- add responsive hamburger menu to dashboard navbar so links are accessible on small screens
- test dashboard mobile navigation links for authenticated users

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68b755bf298483328ce1416e7b623b79