### PR TITLE
Use icons for specials list view toggle

### DIFF
--- a/templates/app/list.html
+++ b/templates/app/list.html
@@ -19,38 +19,6 @@
 
         <!-- Action Buttons -->
         <div class="flex flex-col sm:flex-row gap-2 sm:gap-3 w-full sm:w-auto">
-            <!-- List Button -->
-            <a href="?view=list"
-               class="{% if current_view == 'list' %}
-                  bg-[#f08000] text-white px-4 py-2 rounded-md shadow-md text-center font-semibold
-                  transition transform duration-200 ease-in-out
-                  hover:bg-[#ff9933] hover:scale-105 hover:shadow-lg
-                  focus:outline-none focus:ring-2 focus:ring-[#f08000]/50
-               {% else %}
-                  bg-white text-[#49475B] border border-[#49475B] px-4 py-2 rounded-md text-center font-semibold
-                  transition transform duration-200 ease-in-out
-                  hover:bg-slate-100 hover:scale-105 hover:shadow-sm
-                  focus:outline-none focus:ring-2 focus:ring-[#49475B]/50
-               {% endif %}">
-                List
-            </a>
-
-            <!-- Calendar Button -->
-            <a href="?view=calendar"
-               class="{% if current_view == 'calendar' %}
-                  bg-[#f08000] text-white px-4 py-2 rounded-md shadow-md text-center font-semibold
-                  transition transform duration-200 ease-in-out
-                  hover:bg-[#ff9933] hover:scale-105 hover:shadow-lg
-                  focus:outline-none focus:ring-2 focus:ring-[#f08000]/50
-               {% else %}
-                  bg-white text-[#49475B] border border-[#49475B] px-4 py-2 rounded-md text-center font-semibold
-                  transition transform duration-200 ease-in-out
-                  hover:bg-slate-100 hover:scale-105 hover:shadow-sm
-                  focus:outline-none focus:ring-2 focus:ring-[#49475B]/50
-               {% endif %}">
-                Calendar
-            </a>
-
             <!-- Create Special Button -->
             <a href="{% url 'create_special' %}"
                class="bg-[#f08000] text-white font-semibold px-4 py-2 rounded-md text-center
@@ -61,6 +29,17 @@
                 + Create Special
             </a>
         </div>
+    </div>
+</div>
+
+<div class="flex justify-end mb-4">
+    <div class="flex space-x-4 text-xl">
+        <a href="?view=list" class="{% if current_view == 'list' %}text-[#f08000]{% else %}text-slate-500{% endif %}">
+            <i class="fa-solid fa-list"></i>
+        </a>
+        <a href="?view=calendar" class="{% if current_view == 'calendar' %}text-[#f08000]{% else %}text-slate-500{% endif %}">
+            <i class="fa-solid fa-calendar"></i>
+        </a>
     </div>
 </div>
 

--- a/tests/tests_calendar_view.py
+++ b/tests/tests_calendar_view.py
@@ -48,6 +48,12 @@ class SpecialsListToggleTests(TestCase):
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.default_view, "calendar")
 
+    def test_list_view_has_toggle_icons(self):
+        response = self.client.get(reverse("specials_list"))
+        html = response.content.decode()
+        self.assertIn("fa-list", html)
+        self.assertIn("fa-calendar", html)
+
 
 class CalendarEventsTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- replace List/Calendar buttons with small FontAwesome icons below the header
- ensure list page renders toggle icons via new test

## Testing
- `python manage.py test` *(fails: Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b4c06b48332a4debbe989d6542d