### PR TITLE
Require email for subuser creation

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,4 +1,7 @@
 from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+
 from .models import Special
 
 
@@ -26,3 +29,13 @@ class ContactForm(forms.Form):
     name = forms.CharField(max_length=100)
     email = forms.EmailField()
     message = forms.CharField(widget=forms.Textarea)
+
+
+class SubUserCreationForm(UserCreationForm):
+    """User creation form requiring an email for subusers."""
+
+    email = forms.EmailField(required=True)
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = UserCreationForm.Meta.fields + ("email",)

--- a/app/views.py
+++ b/app/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import UserCreationForm
 from django.contrib import messages
 from django.http import JsonResponse, HttpResponse, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
@@ -35,7 +34,7 @@ from .models import (
     Transaction,
     SubUserProfile,
 )
-from .forms import SpecialForm, ContactForm
+from .forms import SpecialForm, ContactForm, SubUserCreationForm
 from app.integrations.google import *
 from app.integrations.outscraper import fetch_place_details
 import threading
@@ -239,7 +238,7 @@ def dashboard(request):
         'stats': stats,
         'show_location_modal': show_location_modal,
         'google_locations': locations,
-        'subuserform': UserCreationForm(),
+        'subuserform': SubUserCreationForm(),
         "subusers": subusers,
     }
     return render(request, 'app/dashboard.html', context)
@@ -249,7 +248,7 @@ def add_subuser(request):
     """Create a subuser tied to the current user."""
     if request.method == "POST":
         logger.debug("POST received for add_subuser by %s", request.user)
-        subuserform = UserCreationForm(request.POST)
+        subuserform = SubUserCreationForm(request.POST)
         if subuserform.is_valid():
             logger.debug("Form is valid. Cleaned data: %s", subuserform.cleaned_data)
             subuser = subuserform.save()
@@ -275,7 +274,7 @@ def add_subuser(request):
             )
     else:
         logger.debug("GET request for add_subuser form by %s", request.user)
-        subuserform = UserCreationForm()
+        subuserform = SubUserCreationForm()
 
     return render(request, "app/partials/add_subuser.html", {"subuserform": subuserform})
 

--- a/templates/app/dashboard.html
+++ b/templates/app/dashboard.html
@@ -124,7 +124,7 @@
 <ul class="divide-y divide-gray-200 mb-3">
   {% for sub in subusers %}
     <li class="flex justify-between items-center py-3 my-2 space-x-3" id="subuser-listitem-{{ sub.id}}">
-      <span class="text-gray-800 text-2xl">{{ sub.user.username }}</span>
+      <span class="text-gray-800 text-2xl">{{ sub.user.username }} ({{ sub.user.email }})</span>
       <div class="flex items-center space-x-2">
         <!-- Reset password badge -->
         <button

--- a/templates/app/partials/add_subuser.html
+++ b/templates/app/partials/add_subuser.html
@@ -17,6 +17,17 @@
         {% endif %}
       </div>
 
+      <!-- Email -->
+      <div>
+        <label for="{{ subuserform.email.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+          {{ subuserform.email.label }}
+        </label>
+        {{ subuserform.email }}
+        {% if subuserform.email.errors %}
+          <p class="mt-1 text-sm text-red-600">{{ subuserform.email.errors }}</p>
+        {% endif %}
+      </div>
+
       <!-- Password -->
       <div>
         <label for="{{ subuserform.password1.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">

--- a/tests/tests_subuser.py
+++ b/tests/tests_subuser.py
@@ -24,3 +24,35 @@ class SubuserDashboardTests(TestCase):
         self.client.login(username="sub", password="pass123")
         response = self.client.get(reverse("dashboard"))
         self.assertNotContains(response, "Billing")
+
+    def test_add_subuser_requires_email(self):
+        """Creating a subuser without email should fail."""
+        self.client.login(username="owner", password="pass123")
+        response = self.client.post(
+            reverse("add_subuser"),
+            {
+                "username": "sub",
+                "password1": "pass12345",
+                "password2": "pass12345",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(User.objects.count(), 1)
+
+    def test_dashboard_lists_subuser_email(self):
+        """Dashboard should display subuser email."""
+        self.client.login(username="owner", password="pass123")
+        self.client.post(
+            reverse("add_subuser"),
+            {
+                "username": "sub",
+                "email": "sub@example.com",
+                "password1": "pass12345",
+                "password2": "pass12345",
+            },
+        )
+        self.assertTrue(
+            User.objects.filter(username="sub", email="sub@example.com").exists()
+        )
+        response = self.client.get(reverse("dashboard"))
+        self.assertContains(response, "sub@example.com")


### PR DESCRIPTION
## Summary
- require email when creating subusers
- display subuser email on dashboard team list
- test subuser email requirements and display

## Testing
- `python manage.py test -v 2` *(fails: app.Special.image: (fields.E210) Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68baf87cd7e88332be3243dd700a0e0f