### PR TITLE
Use special image for calendar day background

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -552,6 +552,7 @@ def specials_list(request):
                     "color": color,
                     "edit_url": reverse("special_edit", args=[s.id]),
                     "card_url": reverse("special_card_partial", args=[s.id]),
+                    "image": s.image.url if s.image else "",
                 }
             )
         context = {

--- a/templates/app/calendar.html
+++ b/templates/app/calendar.html
@@ -32,14 +32,12 @@
 
 /* Has special */
 .fc-event {
-  background: #58B09C !important;  /* seafoam green */
-  border-radius: 0.5rem;
+  background: transparent !important;
   border: none;
   text-align: center;
   font-size: 0.9rem;
   font-weight: 600;
   color: white;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
 }
 
 </style>
@@ -175,6 +173,14 @@ document.addEventListener('DOMContentLoaded', function() {
         'duration-150',
         'hover:scale-105'
       );
+      const dateStr = arg.date.toISOString().slice(0, 10);
+      const dayEvents = events.filter(e => e.start.slice(0, 10) === dateStr && e.image);
+      if (dayEvents.length > 0) {
+        arg.el.style.backgroundImage = `url('${dayEvents[0].image}')`;
+        arg.el.style.backgroundSize = 'cover';
+        arg.el.style.backgroundPosition = 'center';
+        arg.el.style.color = 'white';
+      }
     }
   });
 

--- a/tests/tests_calendar_view.py
+++ b/tests/tests_calendar_view.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from app.models import Special, UserProfile
 from app.utils import month_cells
@@ -91,3 +92,24 @@ class CalendarEventsTests(TestCase):
         colors = {e["id"]: e["color"] for e in events}
         self.assertEqual(colors[str(active.id)], "#22c55e")
         self.assertEqual(colors[str(expired.id)], "#6b7280")
+
+    def test_calendar_view_includes_image_urls(self):
+        start = timezone.now()
+        end = start + timedelta(hours=1)
+        image = SimpleUploadedFile("test.jpg", b"filecontent", content_type="image/jpeg")
+        special = Special.objects.create(
+            user=self.user,
+            title="With Image",
+            description="desc",
+            price=5,
+            start_date=start,
+            end_date=end,
+            status="active",
+            cta_type="web",
+            cta_url="",
+            image=image,
+        )
+        response = self.client.get(reverse("specials_list") + "?view=calendar")
+        events = response.context["events"]
+        images = {e["id"]: e.get("image") for e in events}
+        self.assertEqual(images[str(special.id)], special.image.url)


### PR DESCRIPTION
## Summary
- show a special's image in the calendar day cell when one exists
- include special image URLs in calendar event data
- test that calendar events expose image URLs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bb50f1f6b08332a4f6238d8ad0e803