### PR TITLE
Use special image for calendar day background

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -551,15 +551,14 @@ def specials_list(request):
                     "end": s.end_date.isoformat(),
                     "color": color,
                     "edit_url": reverse("special_edit", args=[s.id]),
-                    "card_url": reverse("special_card_partial", args=[s.id]),
+                    "form_url": reverse("special_form_edit_partial", args=[s.id]),
+                    "image": s.image.url if s.image else "",
                 }
             )
         context = {
             "events": events,
             "create_url": reverse("create_special"),
             "current_view": "calendar",
-            "edit_partial_url": reverse("special_form_edit_partial", args=[s.id]),
-
         }
         template = "app/calendar.html"
     else:

--- a/templates/app/calendar.html
+++ b/templates/app/calendar.html
@@ -32,14 +32,12 @@
 
 /* Has special */
 .fc-event {
-  background: #58B09C !important;  /* seafoam green */
-  border-radius: 0.5rem;
+  background: transparent !important;
   border: none;
   text-align: center;
   font-size: 0.9rem;
   font-weight: 600;
   color: white;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
 }
 
 </style>
@@ -129,6 +127,11 @@ document.addEventListener('DOMContentLoaded', function() {
   const calendarEl = document.getElementById('calendar');  // <-- define it here
   const createUrl = "{{ create_url }}";
 
+  function dateInRange(dateStr, startStr, endStr) {
+    const day = new Date(dateStr);
+    return day >= new Date(startStr) && day <= new Date(endStr);
+  }
+
   function openModal(url) {
     const modal = document.getElementById('modal');
     const body = document.getElementById('modal-body');
@@ -150,13 +153,11 @@ document.addEventListener('DOMContentLoaded', function() {
     events: events,
     selectable: true,
     dateClick: function(info) {
-      const dayEvents = calendar.getEvents().filter(e => e.startStr === info.dateStr);
+      const dayEvents = events.filter(e => dateInRange(info.dateStr, e.start, e.end));
       if (dayEvents.length > 0) {
-        const url = dayEvents[0].extendedProps.card_url;
-        openModal(url);
+        openModal(dayEvents[0].form_url);
       } else {
-        const url = "{% url 'special_form_create_partial' %}?date=" + info.dateStr;
-        openModal(url);
+        openModal(`${createUrl}?date=${info.dateStr}`);
       }
     },
     eventContent: function(arg) {
@@ -175,6 +176,14 @@ document.addEventListener('DOMContentLoaded', function() {
         'duration-150',
         'hover:scale-105'
       );
+      const dateStr = arg.date.toISOString().slice(0, 10);
+      const dayEvents = events.filter(e => dateInRange(dateStr, e.start, e.end) && e.image);
+      if (dayEvents.length > 0) {
+        arg.el.style.backgroundImage = `url('${dayEvents[0].image}')`;
+        arg.el.style.backgroundSize = 'cover';
+        arg.el.style.backgroundPosition = 'center';
+        arg.el.style.color = 'white';
+      }
     }
   });
 

--- a/tests/tests_calendar_view.py
+++ b/tests/tests_calendar_view.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from app.models import Special, UserProfile
 from app.utils import month_cells
@@ -91,3 +92,48 @@ class CalendarEventsTests(TestCase):
         colors = {e["id"]: e["color"] for e in events}
         self.assertEqual(colors[str(active.id)], "#22c55e")
         self.assertEqual(colors[str(expired.id)], "#6b7280")
+
+    def test_calendar_view_includes_image_urls(self):
+        start = timezone.now()
+        end = start + timedelta(hours=1)
+        image = SimpleUploadedFile("test.jpg", b"filecontent", content_type="image/jpeg")
+        special = Special.objects.create(
+            user=self.user,
+            title="With Image",
+            description="desc",
+            price=5,
+            start_date=start,
+            end_date=end,
+            status="active",
+            cta_type="web",
+            cta_url="",
+            image=image,
+        )
+        response = self.client.get(reverse("specials_list") + "?view=calendar")
+        events = response.context["events"]
+        images = {e["id"]: e.get("image") for e in events}
+        self.assertEqual(images[str(special.id)], special.image.url)
+
+    def test_calendar_events_include_form_url_and_span(self):
+        start = timezone.now()
+        end = start + timedelta(days=2)
+        special = Special.objects.create(
+            user=self.user,
+            title="Multi", 
+            description="desc",
+            price=5,
+            start_date=start,
+            end_date=end,
+            status="active",
+            cta_type="web",
+            cta_url="",
+        )
+        response = self.client.get(reverse("specials_list") + "?view=calendar")
+        events = response.context["events"]
+        event = next(e for e in events if e["id"] == str(special.id))
+        self.assertEqual(event["start"], start.isoformat())
+        self.assertEqual(event["end"], end.isoformat())
+        self.assertEqual(
+            event["form_url"],
+            reverse("special_form_edit_partial", args=[special.id]),
+        )


### PR DESCRIPTION
## Summary
- show a special's image in the calendar day cell when one exists
- include special image URLs and edit form URLs in calendar event data
- open the special's edit form when clicking a day with a special; otherwise open the create form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68bb50f1f6b08332a4f6238d8ad0e803