### PR TITLE
Add interactive idea grid with menu suggestions

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -46,7 +46,22 @@ logger = logging.getLogger(__name__)
 def home(request):
     """Home page view."""
     articles = Article.objects.all()[:5]
-    return render(request, "app/home.html", {"articles": articles})
+    concepts = [
+        "Italian",
+        "Mexican",
+        "Chinese",
+        "Japanese",
+        "Indian",
+        "Mediterranean",
+        "American",
+        "Thai",
+        "Vegan",
+    ]
+    return render(
+        request,
+        "app/home.html",
+        {"articles": articles, "concepts": concepts},
+    )
 
 
 def resources(request):
@@ -81,6 +96,17 @@ def contact(request):
     else:
         form = ContactForm()
     return render(request, "app/contact.html", {"form": form})
+
+
+def menu_suggestions(request):
+    """Return simple menu suggestions for a given concept."""
+    concept = request.GET.get("concept", "")
+    suggestions = [f"{concept} menu item {i}" for i in range(1, 11)]
+    return render(
+        request,
+        "app/partials/menu_suggestions.html",
+        {"suggestions": suggestions},
+    )
 
 def register_view(request):
     """Registration page"""

--- a/specials/urls.py
+++ b/specials/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path('resources/<slug:slug>/', views.article_detail, name='article_detail'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('menu-suggestions/', views.menu_suggestions, name='menu_suggestions'),
     path('register/', views.register_view, name='register'),
     path('login/', views.login_view, name='login'),
     path('logout/', views.logout_view, name='logout'),

--- a/templates/app/home.html
+++ b/templates/app/home.html
@@ -31,9 +31,9 @@
     </div>
   </section>
 
-  <!-- Features Funnel -->
-{% include 'app/partials/idea_partial.html' %}
-    {% include 'app/partials/planning_partial.html' %}
+    <!-- Features Funnel -->
+    {% include 'app/partials/idea_partial.html' with concepts=concepts %}
+      {% include 'app/partials/planning_partial.html' %}
 
 
   <!-- Pricing -->

--- a/templates/app/partials/idea_partial.html
+++ b/templates/app/partials/idea_partial.html
@@ -1,0 +1,11 @@
+<style>
+.idea-card{transition:transform 0.6s;}
+.idea-card.flipped{transform:rotateY(180deg);}
+</style>
+<div id="idea-grid" class="grid grid-cols-3 gap-4">
+  {% for concept in concepts %}
+  <div class="idea-card p-4 bg-white border rounded shadow cursor-pointer text-center" onclick="this.classList.add('flipped')" hx-get="{% url 'menu_suggestions' %}?concept={{ concept }}" hx-target="#idea-grid" hx-swap="outerHTML">
+    {{ concept }}
+  </div>
+  {% endfor %}
+</div>

--- a/templates/app/partials/menu_suggestions.html
+++ b/templates/app/partials/menu_suggestions.html
@@ -1,0 +1,5 @@
+<ul id="idea-grid" class="list-disc pl-5">
+  {% for item in suggestions %}
+  <li>{{ item }}</li>
+  {% endfor %}
+</ul>

--- a/tests/tests_idea_partial.py
+++ b/tests/tests_idea_partial.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class IdeaPartialTests(TestCase):
+    """Tests for the idea partial and menu suggestions endpoint."""
+
+    def test_menu_suggestions_returns_ten_items(self):
+        response = self.client.get(
+            reverse("menu_suggestions"), {"concept": "Italian"}, follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<li", count=10)
+
+    def test_home_shows_idea_grid(self):
+        response = self.client.get(reverse("home"), follow=True)
+        self.assertContains(response, "Italian")
+        self.assertContains(response, "hx-get", count=9)


### PR DESCRIPTION
## Summary
- Display 3x3 idea grid that flips and fetches menu suggestions via HTMX
- Serve suggestion data through new `menu_suggestions` view and URL
- Cover idea grid and suggestion endpoint with tests

## Testing
- `python manage.py test tests.tests_idea_partial`
- `python manage.py test tests` *(fails: ImportError and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf23f24a088332832fe3362dd90f00