### PR TITLE
Fix static index console errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,31 +14,240 @@
   <meta name="twitter:title" content="Today&rsquo;s Specials — What&rsquo;s Good Today?" />
   <meta name="twitter:description" content="See today&rsquo;s local restaurant specials in one place." />
   <meta name="twitter:image" content="https://appertivo.com/og-image.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.2/anime.min.js" defer></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ember: '#ff4f1f',
-            yolk: '#ffd166',
-            basil: '#3d7a4f',
-            cream: '#fff7ea',
-            ink: '#17120f'
-          },
-          fontFamily: {
-            display: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif']
-          },
-          boxShadow: {
-            glow: '0 30px 100px rgba(255, 79, 31, 0.32)',
-            card: '0 24px 70px rgba(23, 18, 15, 0.16)'
-          }
-        }
-      }
-    };
-  </script>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='16' fill='%23ff4f1f'/%3E%3Ctext x='32' y='43' text-anchor='middle' font-size='35' fill='white'%3E%E2%98%85%3C/text%3E%3C/svg%3E" />
   <style>
+
+    :root {
+      --ember: #ff4f1f;
+      --yolk: #ffd166;
+      --basil: #3d7a4f;
+      --cream: #fff7ea;
+      --ink: #17120f;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { margin: 0; }
+    button, input, textarea, select { font: inherit; }
+    button { border: 0; cursor: pointer; }
+    a { color: inherit; text-decoration: none; }
+
+    .absolute { position: absolute; }
+    .relative { position: relative; }
+    .fixed { position: fixed; }
+    .z-10 { z-index: 10; }
+    .inset-0 { inset: 0; }
+    .top-20 { top: 5rem; }
+    .top-24 { top: 6rem; }
+    .bottom-14 { bottom: 3.5rem; }
+    .-bottom-32 { bottom: -8rem; }
+    .-left-4 { left: -1rem; }
+    .-right-2 { right: -.5rem; }
+    .-right-28 { right: -7rem; }
+    .left-1\/4 { left: 25%; }
+
+    .mx-auto { margin-left: auto; margin-right: auto; }
+    .-mt-1 { margin-top: -.25rem; }
+    .mb-4 { margin-bottom: 1rem; }
+    .ml-3 { margin-left: .75rem; }
+    .mt-1 { margin-top: .25rem; }
+    .mt-2 { margin-top: .5rem; }
+    .mt-3 { margin-top: .75rem; }
+    .mt-4 { margin-top: 1rem; }
+    .mt-5 { margin-top: 1.25rem; }
+    .mt-6 { margin-top: 1.5rem; }
+    .mt-7 { margin-top: 1.75rem; }
+    .mt-8 { margin-top: 2rem; }
+    .mt-9 { margin-top: 2.25rem; }
+    .mt-10 { margin-top: 2.5rem; }
+    .mt-12 { margin-top: 3rem; }
+
+    .block { display: block; }
+    .flex { display: flex; }
+    .grid { display: grid; }
+    .hidden { display: none; }
+    .inline-flex { display: inline-flex; }
+    .place-items-center { place-items: center; }
+    .items-center { align-items: center; }
+    .items-start { align-items: flex-start; }
+    .justify-between { justify-content: space-between; }
+    .justify-center { justify-content: center; }
+    .flex-1 { flex: 1 1 0%; }
+    .shrink-0 { flex-shrink: 0; }
+    .flex-col { flex-direction: column; }
+    .flex-wrap { flex-wrap: wrap; }
+    .grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .gap-2 { gap: .5rem; }
+    .gap-3 { gap: .75rem; }
+    .gap-4 { gap: 1rem; }
+    .gap-5 { gap: 1.25rem; }
+    .gap-8 { gap: 2rem; }
+    .gap-12 { gap: 3rem; }
+    .space-y-4 > * + * { margin-top: 1rem; }
+
+    .h-10 { height: 2.5rem; }
+    .h-24 { height: 6rem; }
+    .h-72 { height: 18rem; }
+    .h-96 { height: 24rem; }
+    .w-1 { width: .25rem; }
+    .w-10 { width: 2.5rem; }
+    .w-24 { width: 6rem; }
+    .w-72 { width: 18rem; }
+    .w-96 { width: 24rem; }
+    .w-full { width: 100%; }
+    .min-h-screen { min-height: 100vh; }
+    .min-w-0 { min-width: 0; }
+    .max-w-xl { max-width: 36rem; }
+    .max-w-2xl { max-width: 42rem; }
+    .max-w-3xl { max-width: 48rem; }
+    .max-w-4xl { max-width: 56rem; }
+    .max-w-5xl { max-width: 64rem; }
+    .max-w-7xl { max-width: 80rem; }
+
+    .overflow-hidden { overflow: hidden; }
+    .whitespace-nowrap { white-space: nowrap; }
+    .rounded-full { border-radius: 9999px; }
+    .rounded-2xl { border-radius: 1rem; }
+    .rounded-3xl { border-radius: 1.5rem; }
+    .rounded-\[2rem\] { border-radius: 2rem; }
+    .rounded-\[2\.5rem\] { border-radius: 2.5rem; }
+    .rounded-\[3rem\] { border-radius: 3rem; }
+    .border { border: 1px solid; }
+    .border-y { border-top: 1px solid; border-bottom: 1px solid; }
+    .border-\[14px\] { border-width: 14px; }
+    .border-cream\/20 { border-color: rgba(255,247,234,.2); }
+    .border-ink { border-color: var(--ink); }
+    .border-ink\/10 { border-color: rgba(23,18,15,.1); }
+    .border-ink\/15 { border-color: rgba(23,18,15,.15); }
+    .border-white\/60 { border-color: rgba(255,255,255,.6); }
+    .ring-1 { box-shadow: 0 0 0 1px var(--ring-color, transparent); }
+    .ring-ink\/5 { --ring-color: rgba(23,18,15,.05); }
+
+    .bg-basil { background-color: var(--basil); }
+    .bg-cream { background-color: var(--cream); }
+    .bg-ember { background-color: var(--ember); }
+    .bg-ember\/25 { background-color: rgba(255,79,31,.25); }
+    .bg-ink { background-color: var(--ink); }
+    .bg-ink\/20 { background-color: rgba(23,18,15,.2); }
+    .bg-white { background-color: #fff; }
+    .bg-white\/50 { background-color: rgba(255,255,255,.5); }
+    .bg-white\/55 { background-color: rgba(255,255,255,.55); }
+    .bg-white\/60 { background-color: rgba(255,255,255,.6); }
+    .bg-yolk { background-color: var(--yolk); }
+    .bg-yolk\/50 { background-color: rgba(255,209,102,.5); }
+    .bg-gradient-to-br { background-image: linear-gradient(to bottom right, var(--gradient-from), var(--gradient-to)); }
+    .from-basil { --gradient-from: var(--basil); }
+    .from-pink-300 { --gradient-from: #f9a8d4; }
+    .from-yolk { --gradient-from: var(--yolk); }
+    .to-ember { --gradient-to: var(--ember); }
+    .to-ink { --gradient-to: var(--ink); }
+    .to-yolk { --gradient-to: var(--yolk); }
+    .blur-3xl { filter: blur(64px); }
+    .backdrop-blur, .backdrop-blur-xl { backdrop-filter: blur(16px); }
+
+    .p-4 { padding: 1rem; }
+    .p-6 { padding: 1.5rem; }
+    .p-8 { padding: 2rem; }
+    .px-2 { padding-left: .5rem; padding-right: .5rem; }
+    .px-3 { padding-left: .75rem; padding-right: .75rem; }
+    .px-4 { padding-left: 1rem; padding-right: 1rem; }
+    .px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+    .px-8 { padding-left: 2rem; padding-right: 2rem; }
+    .py-1 { padding-top: .25rem; padding-bottom: .25rem; }
+    .py-2 { padding-top: .5rem; padding-bottom: .5rem; }
+    .py-3 { padding-top: .75rem; padding-bottom: .75rem; }
+    .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+    .py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+    .py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+    .py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+    .pb-20 { padding-bottom: 5rem; }
+    .pt-16 { padding-top: 4rem; }
+
+    .font-display { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+    .text-center { text-align: center; }
+    .text-xs { font-size: .75rem; line-height: 1rem; }
+    .text-sm { font-size: .875rem; line-height: 1.25rem; }
+    .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+    .text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
+    .text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+    .text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+    .text-5xl { font-size: 3rem; line-height: 1; }
+    .text-6xl { font-size: 3.75rem; line-height: 1; }
+    .font-semibold { font-weight: 600; }
+    .font-bold { font-weight: 700; }
+    .font-extrabold { font-weight: 800; }
+    .font-black { font-weight: 900; }
+    .uppercase { text-transform: uppercase; }
+    .leading-6 { line-height: 1.5rem; }
+    .leading-7 { line-height: 1.75rem; }
+    .leading-8 { line-height: 2rem; }
+    .leading-none { line-height: 1; }
+    .leading-tight { line-height: 1.25; }
+    .leading-\[0\.88\] { line-height: .88; }
+    .tracking-tight { letter-spacing: -.025em; }
+    .tracking-widest { letter-spacing: .1em; }
+    .tracking-\[-0\.05em\] { letter-spacing: -.05em; }
+    .tracking-\[-0\.06em\] { letter-spacing: -.06em; }
+    .tracking-\[-0\.08em\] { letter-spacing: -.08em; }
+    .tracking-\[0\.2em\] { letter-spacing: .2em; }
+    .tracking-\[0\.22em\] { letter-spacing: .22em; }
+    .tracking-\[0\.24em\] { letter-spacing: .24em; }
+    .text-basil { color: var(--basil); }
+    .text-cream { color: var(--cream); }
+    .text-cream\/70 { color: rgba(255,247,234,.7); }
+    .text-ember { color: var(--ember); }
+    .text-ink { color: var(--ink); }
+    .text-ink\/55 { color: rgba(23,18,15,.55); }
+    .text-ink\/60 { color: rgba(23,18,15,.6); }
+    .text-ink\/65 { color: rgba(23,18,15,.65); }
+    .text-ink\/75 { color: rgba(23,18,15,.75); }
+    .text-white { color: #fff; }
+    .text-yolk { color: var(--yolk); }
+
+    .shadow-sm { box-shadow: 0 1px 2px rgba(0,0,0,.05); }
+    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1); }
+    .shadow-card { box-shadow: 0 24px 70px rgba(23, 18, 15, .16); }
+    .shadow-glow { box-shadow: 0 30px 100px rgba(255, 79, 31, .32); }
+    .transition { transition: all .2s ease; }
+
+    .hover\:-translate-y-0\.5:hover { transform: translateY(-.125rem); }
+    .hover\:-translate-y-1:hover { transform: translateY(-.25rem); }
+    .hover\:bg-cream:hover { background-color: var(--cream); }
+    .hover\:bg-ember:hover { background-color: var(--ember); }
+    .hover\:bg-ink:hover { background-color: var(--ink); }
+    .hover\:bg-white:hover { background-color: #fff; }
+    .hover\:bg-yolk:hover { background-color: var(--yolk); }
+    .hover\:text-ink:hover { color: var(--ink); }
+    .group:hover .group-hover\:translate-x-1 { transform: translateX(.25rem); }
+
+    @media (min-width: 640px) {
+      .sm\:-left-10 { left: -2.5rem; }
+      .sm\:-right-10 { right: -2.5rem; }
+      .sm\:inline-flex { display: inline-flex; }
+      .sm\:flex-row { flex-direction: row; }
+      .sm\:p-8 { padding: 2rem; }
+      .sm\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+      .sm\:text-2xl { font-size: 1.5rem; line-height: 2rem; }
+      .sm\:text-6xl { font-size: 3.75rem; line-height: 1; }
+      .sm\:text-7xl { font-size: 4.5rem; line-height: 1; }
+      .sm\:leading-9 { line-height: 2.25rem; }
+    }
+
+    @media (min-width: 768px) {
+      .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+
+    @media (min-width: 1024px) {
+      .lg\:grid-cols-\[\.9fr_1\.1fr\] { grid-template-columns: .9fr 1.1fr; }
+      .lg\:grid-cols-\[1\.02fr_\.98fr\] { grid-template-columns: 1.02fr .98fr; }
+      .lg\:items-center { align-items: center; }
+      .lg\:pt-24 { padding-top: 6rem; }
+      .lg\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+      .lg\:text-8xl { font-size: 6rem; line-height: 1; }
+    }
     .grain::before {
       background-image: radial-gradient(rgba(23, 18, 15, .14) 1px, transparent 1px);
       background-size: 18px 18px;
@@ -276,64 +485,9 @@
   </main>
 
   <script>
-    window.addEventListener('load', () => {
-      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      if (reduceMotion || !window.anime) {
-        document.querySelectorAll('[data-count]').forEach((item) => {
-          item.textContent = item.dataset.count;
-        });
-        return;
-      }
-
-      anime.timeline({ easing: 'easeOutExpo' })
-        .add({ targets: 'nav', translateY: [-24, 0], opacity: [0, 1], duration: 800 })
-        .add({ targets: '.eyebrow', translateY: [18, 0], opacity: [0, 1], duration: 650 }, '-=450')
-        .add({ targets: '.hero-title', translateY: [46, 0], opacity: [0, 1], duration: 900 }, '-=450')
-        .add({ targets: '.hero-copy, .hero-actions', translateY: [26, 0], opacity: [0, 1], delay: anime.stagger(90), duration: 700 }, '-=520')
-        .add({ targets: '.phone-shell', scale: [0.92, 1], rotate: [-3, 0], opacity: [0, 1], duration: 900 }, '-=750')
-        .add({ targets: '.special-card', translateY: [38, 0], rotate: (el) => el.dataset.rotate, opacity: [0, 1], delay: anime.stagger(120), duration: 700 }, '-=550')
-        .add({ targets: '.stat', translateY: [18, 0], opacity: [0, 1], delay: anime.stagger(80), duration: 520 }, '-=620');
-
+    window.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('[data-count]').forEach((item) => {
-        anime({
-          targets: item,
-          innerHTML: [0, Number(item.dataset.count)],
-          round: 1,
-          duration: 1100,
-          easing: 'easeOutCubic',
-          update: () => {
-            item.textContent = item.dataset.count === '0' ? '0' : item.textContent;
-          }
-        });
-      });
-
-      anime({
-        targets: '.float-badge',
-        translateY: [-8, 8],
-        direction: 'alternate',
-        duration: 1800,
-        delay: anime.stagger(250),
-        easing: 'easeInOutSine',
-        loop: true
-      });
-
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (!entry.isIntersecting) return;
-          anime({
-            targets: entry.target,
-            translateY: [30, 0],
-            opacity: [0, 1],
-            duration: 800,
-            easing: 'easeOutExpo'
-          });
-          observer.unobserve(entry.target);
-        });
-      }, { threshold: 0.15 });
-
-      document.querySelectorAll('.section-kicker, .section-title, .feature-card, .parsed-card').forEach((item) => {
-        item.style.opacity = 0;
-        observer.observe(item);
+        item.textContent = item.dataset.count;
       });
     });
   </script>

--- a/tests/test_index_static.py
+++ b/tests/test_index_static.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_index_is_self_contained_and_has_favicon():
+    """The static landing page should not depend on external assets at runtime."""
+    html = Path("index.html").read_text(encoding="utf-8")
+
+    assert 'rel="icon"' in html
+    assert 'https://cdn.tailwindcss.com' not in html
+    assert 'https://cdnjs.cloudflare.com' not in html
+    assert 'tailwind.config' not in html


### PR DESCRIPTION
### Motivation
- Prevent runtime console errors and external CDN/network failures when serving the static landing page by removing runtime dependence on remote Tailwind/AnimeJS assets and missing favicon requests.
- Ensure the static `index.html` remains self-contained for reliable local preview and smoke tests.

### Description
- Replaced the external Tailwind CDN and AnimeJS runtime includes in `index.html` with an inline SVG favicon and an inline CSS block that implements the subset of utility styles used by the page.
- Removed the Anime.js animation code and replaced it with a minimal `DOMContentLoaded` handler that sets visible stat counts from `data-count` attributes so the page does not rely on `anime` being available.
- Added a regression test `tests/test_index_static.py` that asserts `index.html` contains a favicon and does not include `https://cdn.tailwindcss.com`, `https://cdnjs.cloudflare.com` or `tailwind.config`.

### Testing
- Ran `python -m pytest tests/test_index_static.py -q`, which passed successfully.
- Ran `git diff --check` to verify no whitespace/errors in diffs, which passed.
- Attempted to run the full Django test suite with `python manage.py test`, which was blocked by missing `OPENAI_API_KEY` environment variable, and running `OPENAI_API_KEY=test python manage.py test` progressed but failed due to missing `Pillow` required by `ImageField` checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b78200748332939bb53bee978291)